### PR TITLE
fix(spore): Ensure proper Transaction kept

### DIFF
--- a/.changeset/twenty-years-type.md
+++ b/.changeset/twenty-years-type.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/spore": patch
+---
+
+fix(spore): Ensure proper Transaction kept
+  

--- a/packages/spore/src/cobuild/index.ts
+++ b/packages/spore/src/cobuild/index.ts
@@ -164,7 +164,7 @@ export async function prepareSporeTransaction(
   }
 
   const existedActions = extractCobuildActionsFromTx(tx);
-  tx = await signer.prepareTransaction(tx);
+  tx = ccc.Transaction.from(await signer.prepareTransaction(tx));
   injectCobuild(tx, [existedActions, actions].flat());
   return tx;
 }


### PR DESCRIPTION
# What's happening.
Trying to generate a Cluster with CCC directly, calling 
```js
try {
  clusterData = ccc.spore.createSporeCluster({
    signer,
    data: {
      name,
      description,
    },
  })
} catch (error) {
  console.error('Error creating cluster!', error.message)
  // Error creating cluster! tx.setWitnessAt is not a function
}
```

## Comparing
```js
// Fails
console.log(typeof tx, tx instanceof ccc.Transaction) // object true
tx = await signer.prepareTransaction(tx);
console.log(typeof tx, tx instanceof ccc.Transaction) // object false
```

```js
// Passes
console.log(typeof tx, tx instanceof ccc.Transaction) // object true
tx = ccc.Transaction.from(await signer.prepareTransaction(tx));
console.log(typeof tx, tx instanceof ccc.Transaction) // object true
```