### PR TITLE
chore: search manual proxy lock when signer isn't the proxy provider

### DIFF
--- a/.changeset/tame-swans-hammer.md
+++ b/.changeset/tame-swans-hammer.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/spore": patch
+---
+
+Enable searching manual proxy lock for cluster in LockProxy mode
+  


### PR DESCRIPTION
# Description

We are informed that one of community members cannot pass through the transaction verification when creating Spore which Cluster is sealed with ACP lock.

We also found in Spore module, transaction only searches the proxy lock that provided by the signer itself, this logic should extend to support searching arbitrary lock while the signer isn't the proxy provider.
