### PR TITLE
chore(core): bump nostr-lock mainnet cell deps

### DIFF
--- a/.changeset/shaggy-gifts-drum.md
+++ b/.changeset/shaggy-gifts-drum.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/core": patch
+---
+
+chore(core): bump nostr-lock mainnet cell deps
+  

--- a/packages/core/src/client/clientPublicMainnet.advanced.ts
+++ b/packages/core/src/client/clientPublicMainnet.advanced.ts
@@ -290,7 +290,7 @@ export const MAINNET_SCRIPTS: Record<KnownScript, ScriptInfoLike | undefined> =
           cellDep: {
             outPoint: {
               txHash:
-                "0x1911208b136957d5f7c1708a8835edfe8ae1d02700d5cb2c3a6aacf4d5906306",
+                "0x99b116dd1e4f1fa903b70112ae672c18bb34241d3d03a9ad555cd2a611be7327",
               index: 0,
             },
             depType: "code",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

- [x] I have read the [**Contributing Guidelines**](CONTRIBUTING.md)

A new mainnet deployment on nostr-lock script has been taking effect to upgrade multisig signers. No contract code changes in this deployment.

This PR bumps the nostr-lock mainnet config in`ckb-ccc/core` package. More details about the deployment can be found here:

- https://github.com/cryptape/nostr-binding/commit/eef134e0a09dd07ccc367eb4eca84c1a5a73fb8b#diff-4f41397d5fbdd8ce3ab1319d5b3c550296ecbd43050cf95d4baa36d5273d3a24L50