### PR TITLE
fix(core): release JSON-RPC concurrency slots after transport errors

### DIFF
--- a/.changeset/spotty-ants-appear.md
+++ b/.changeset/spotty-ants-appear.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/core": patch
+---
+
+fix(core): release JSON-RPC concurrency slots after transport errors
+  

--- a/packages/core/src/jsonRpc/requestor.test.ts
+++ b/packages/core/src/jsonRpc/requestor.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { RequestorJsonRpc } from "./requestor.js";
+import { JsonRpcPayload, Transport } from "./transports/advanced.js";
+
+function response(payload: JsonRpcPayload, result: unknown) {
+  return {
+    jsonrpc: "2.0",
+    id: payload.id,
+    result,
+  };
+}
+
+describe("RequestorJsonRpc", () => {
+  it("advances the queue after a successful request", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let active = 0;
+    let maxActive = 0;
+    const transport: Transport = {
+      async request(payload) {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        if (payload.id === 0) {
+          await firstPending;
+        }
+        active -= 1;
+        return response(payload, payload.id);
+      },
+    };
+    const requestor = new RequestorJsonRpc("", {
+      maxConcurrent: 1,
+      transport,
+    });
+
+    const first = requestor.requestPayload(requestor.buildPayload("test", []));
+    const second = requestor.requestPayload(requestor.buildPayload("test", []));
+
+    expect(active).toBe(1);
+    releaseFirst?.();
+    await expect(Promise.all([first, second])).resolves.toEqual([0, 1]);
+    expect(maxActive).toBe(1);
+  });
+
+  it("advances the queue after a transport error", async () => {
+    let calls = 0;
+    const transport: Transport = {
+      async request(payload) {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("failed");
+        }
+        return response(payload, "ok");
+      },
+    };
+    const requestor = new RequestorJsonRpc("", {
+      maxConcurrent: 1,
+      transport,
+    });
+
+    const first = requestor
+      .requestPayload(requestor.buildPayload("test", []))
+      .catch((error: unknown) => error);
+    const second = requestor.requestPayload(requestor.buildPayload("test", []));
+
+    await vi.waitFor(() => expect(calls).toBe(2));
+    expect(await first).toEqual(new Error("failed"));
+    await expect(second).resolves.toBe("ok");
+  });
+
+  it("does not exhaust a larger concurrency limit after transport errors", async () => {
+    let calls = 0;
+    const transport: Transport = {
+      async request(payload) {
+        calls += 1;
+        if (calls <= 2) {
+          throw new Error(`failed ${calls}`);
+        }
+        return response(payload, payload.id);
+      },
+    };
+    const requestor = new RequestorJsonRpc("", {
+      maxConcurrent: 2,
+      transport,
+    });
+
+    const results = Promise.allSettled(
+      Array.from({ length: 4 }, () =>
+        requestor.requestPayload(requestor.buildPayload("test", [])),
+      ),
+    );
+
+    await vi.waitFor(() => expect(calls).toBe(4));
+    await expect(results).resolves.toMatchObject([
+      { status: "rejected" },
+      { status: "rejected" },
+      { status: "fulfilled", value: 2 },
+      { status: "fulfilled", value: 3 },
+    ]);
+  });
+});

--- a/packages/core/src/jsonRpc/requestor.ts
+++ b/packages/core/src/jsonRpc/requestor.ts
@@ -129,14 +129,19 @@ export class RequestorJsonRpc {
       await pending;
     }
 
-    this.concurrent += 1;
-    const res = (await this.transport.request(payload)) as {
+    const res = (await (async () => {
+      this.concurrent += 1;
+      try {
+        return await this.transport.request(payload);
+      } finally {
+        this.concurrent -= 1;
+        this.pending.shift()?.();
+      }
+    })()) as {
       id: number;
       error: unknown;
       result: unknown;
     };
-    this.concurrent -= 1;
-    this.pending.shift()?.();
 
     if (res.id !== payload.id) {
       throw new Error(`Id mismatched, got ${res.id}, expected ${payload.id}`);


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

- [x] I have read the [**Contributing Guidelines**](CONTRIBUTING.md)
