### PR TITLE
docs/refine-ai-docs-0803

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Read our [documents](https://docs.ckbccc.com) or [API reference](https://api.ckb
 
 > **Using an AI assistant?** CCC's docs are LLM-friendly: start from [docs.ckbccc.com/llms.txt](https://docs.ckbccc.com/llms.txt) for a curated index with task-oriented reading paths, or [docs.ckbccc.com/llms-full.txt](https://docs.ckbccc.com/llms-full.txt) for the full documentation in a single file. Append `.md` to any docs page URL to get its raw Markdown.
 
+## AI Coding Assistants (Agent Skills)
+
+CKB's Cell model rarely appears in the Ethereum-heavy data most LLMs are trained on, so an unguided assistant will confidently write wrong CCC code (wrong tx ordering, invented methods, `number` where CKB needs `bigint`, EVM-style assumptions). To fix this, CCC ships a set of machine-readable [Agent Skills](https://docs.ckbccc.com/skill.md) under [`skills/`](https://github.com/ckb-devrel/ccc/tree/master/skills) — one hub skill (`ckb-ccc-fundamentals`) plus a spoke skill per task area (signer setup, transactions, UDT, Spore, playground, examples).
+
+Install them into Cursor, Claude Code, GitHub Copilot, Windsurf, Codex, and 60+ other tools with one command, using the open-source [`skills`](https://github.com/vercel-labs/skills) CLI:
+
+```bash
+npx skills add ckb-devrel/ccc --all
+```
+
+See [AI Resources](https://docs.ckbccc.com/docs/ai-resources) for full setup instructions per tool, how to verify a skill actually loaded, and prompting tips.
+
 ## Try in the Playground
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install them into Cursor, Claude Code, GitHub Copilot, Windsurf, Codex, and 60+ 
 npx skills add ckb-devrel/ccc --all
 ```
 
-See [AI Resources](https://docs.ckbccc.com/docs/ai-resources) for full setup instructions per tool, how to verify a skill actually loaded, and prompting tips.
+See [AI Resources](https://docs.ckbccc.com/en/docs/ai-resources) for full setup instructions per tool, how to verify a skill actually loaded, and prompting tips.
 
 ## Try in the Playground
 
@@ -72,7 +72,7 @@ See [AI Resources](https://docs.ckbccc.com/docs/ai-resources) for full setup ins
 
 The CCC Playground is an integrated testing environment in web browsers that supports data visualization and code-sharing. [Click the link](https://live.ckbccc.com/) to run your code without the annoying preparation and watch how the code works, exploring CCC's capabilities.
 
-For an explanation of the visual elements and interface components in the playground, please refer to [the CCC Playground guide](https://docs.ckbccc.com/docs/guides/playground).
+For an explanation of the visual elements and interface components in the playground, please refer to [the CCC Playground guide](https://docs.ckbccc.com/en/docs/guides/playground).
 
 ## Quick Start with `create-ccc-app`
 
@@ -126,7 +126,7 @@ import { cccA } from "@ckb-ccc/<package-name>/advanced";
 
 The CCC App is a mini-toolset for CKB, showcasing some basic scenarios. You can still [try the CCC App here](https://app.ckbccc.com) even if you are not a developer. 
 
-To learn more examples, visit [the documentation](https://docs.ckbccc.com/docs/code-examples).
+To learn more examples, visit [the documentation](https://docs.ckbccc.com/en/docs/code-examples).
 
 ### Transaction Composing
 
@@ -150,7 +150,7 @@ That's it! The transaction is sent.
 
 [Click here to read the full example of transferring native CKB token.](https://live.ckbccc.com/?src=https://raw.githubusercontent.com/ckb-devrel/ccc/refs/heads/master/packages/examples/src/transfer.ts)
 
-Additional examples can be found in [the documentation](https://docs.ckbccc.com/docs/code-examples).
+Additional examples can be found in [the documentation](https://docs.ckbccc.com/en/docs/code-examples).
 
 ## Build and Run
 

--- a/packages/docs/content/docs/ai-resources/index.mdx
+++ b/packages/docs/content/docs/ai-resources/index.mdx
@@ -8,7 +8,7 @@ import { Wrench, MessageSquare, ShieldCheck } from 'lucide-react';
 
 This section is for developers who use an AI coding assistant (Cursor, Claude Code, GitHub Copilot, Windsurf, ChatGPT, …) to build on CKB with CCC. Its only goal: make your assistant write **correct** CCC code instead of confidently wrong code.
 
-Why the extra effort is needed: CKB uses the **Cell model** (a generalized UTXO model), which barely appears in the Ethereum-heavy data most LLMs were trained on. Left unguided, an assistant will produce CCC code that looks right but isn't — wrong transaction ordering, invented methods, `number` where CKB needs `bigint`, EVM-style assumptions. CCC ships a set of machine-readable [Agent Skills](/skill.md) — one hub skill (`ckb-ccc-fundamentals`) plus a spoke skill per task area (signer setup, transactions, UDT, Spore, playground, examples) — that encode the CCC-specific rules; these pages show you how to feed them to your tool and get reliable output.
+Why the extra effort is needed: CKB uses the **Cell model** (a generalized UTXO model), which barely appears in the Ethereum-heavy data most LLMs were trained on. Left unguided, an assistant will produce CCC code that looks right but isn't — wrong transaction ordering, invented methods, `number` where CKB needs `bigint`, EVM-style assumptions. CCC ships a set of machine-readable [Agent Skills](https:docs.ckbccc.com/skill.md) — one hub skill (`ckb-ccc-fundamentals`) plus a spoke skill per task area (signer setup, transactions, UDT, Spore, playground, examples) — that encode the CCC-specific rules; these pages show you how to feed them to your tool and get reliable output.
 
 ## Do this once, then it just works
 

--- a/packages/docs/content/docs/ai-resources/index.mdx
+++ b/packages/docs/content/docs/ai-resources/index.mdx
@@ -8,7 +8,7 @@ import { Wrench, MessageSquare, ShieldCheck } from 'lucide-react';
 
 This section is for developers who use an AI coding assistant (Cursor, Claude Code, GitHub Copilot, Windsurf, ChatGPT, …) to build on CKB with CCC. Its only goal: make your assistant write **correct** CCC code instead of confidently wrong code.
 
-Why the extra effort is needed: CKB uses the **Cell model** (a generalized UTXO model), which barely appears in the Ethereum-heavy data most LLMs were trained on. Left unguided, an assistant will produce CCC code that looks right but isn't — wrong transaction ordering, invented methods, `number` where CKB needs `bigint`, EVM-style assumptions. CCC ships a set of machine-readable [Agent Skills](https:docs.ckbccc.com/skill.md) — one hub skill (`ckb-ccc-fundamentals`) plus a spoke skill per task area (signer setup, transactions, UDT, Spore, playground, examples) — that encode the CCC-specific rules; these pages show you how to feed them to your tool and get reliable output.
+Why the extra effort is needed: CKB uses the **Cell model** (a generalized UTXO model), which barely appears in the Ethereum-heavy data most LLMs were trained on. Left unguided, an assistant will produce CCC code that looks right but isn't — wrong transaction ordering, invented methods, `number` where CKB needs `bigint`, EVM-style assumptions. CCC ships a set of machine-readable [Agent Skills](https://docs.ckbccc.com/skill.md) — one hub skill (`ckb-ccc-fundamentals`) plus a spoke skill per task area (signer setup, transactions, UDT, Spore, playground, examples) — that encode the CCC-specific rules; these pages show you how to feed them to your tool and get reliable output.
 
 ## Do this once, then it just works
 

--- a/packages/docs/content/docs/ai-resources/index.zh.mdx
+++ b/packages/docs/content/docs/ai-resources/index.zh.mdx
@@ -8,7 +8,7 @@ import { Wrench, MessageSquare, ShieldCheck } from 'lucide-react';
 
 本部分面向使用 AI 编程助手（Cursor、Claude Code、GitHub Copilot、Windsurf、ChatGPT……）在 CKB 上基于 CCC 开发的开发者。其唯一目标是：让你的助手写出**正确**的 CCC 代码，而不是自信满满地写出错误代码。
 
-为什么需要额外花这些功夫：CKB 采用 **Cell 模型**（泛化的 UTXO 模型），这在 LLM 训练数据中占绝大比重的以太坊相关内容里几乎不存在。如果不加引导，助手生成的 CCC 代码看起来像那么回事，但实际是错的——交易顺序不对、方法凭空捏造、该用 `bigint` 的地方用了 `number`、沿袭 EVM 风格的前提假设。CCC 提供了一套机器可读的 [Agent Skills](/skill.md)——包含一个 hub skill（`ckb-ccc-fundamentals`）和每个任务领域对应的 spoke skill（signer 配置、交易、UDT、Spore、playground、示例）——其中编码了 CCC 特有的规则；本部分页面会告诉你如何将这些 skill 喂给工具，并稳定获得正确输出。
+为什么需要额外花这些功夫：CKB 采用 **Cell 模型**（泛化的 UTXO 模型），这在 LLM 训练数据中占绝大比重的以太坊相关内容里几乎不存在。如果不加引导，助手生成的 CCC 代码看起来像那么回事，但实际是错的——交易顺序不对、方法凭空捏造、该用 `bigint` 的地方用了 `number`、沿袭 EVM 风格的前提假设。CCC 提供了一套机器可读的 [Agent Skills](https://docs.ckbccc.com/skill.md)——包含一个 hub skill（`ckb-ccc-fundamentals`）和每个任务领域对应的 spoke skill（signer 配置、交易、UDT、Spore、playground、示例）——其中编码了 CCC 特有的规则；本部分页面会告诉你如何将这些 skill 喂给工具，并稳定获得正确输出。
 
 ## 一次配置，之后无需操心
 

--- a/packages/docs/content/docs/ai-resources/prompting-best-practices.mdx
+++ b/packages/docs/content/docs/ai-resources/prompting-best-practices.mdx
@@ -1,143 +1,107 @@
 ---
 title: Prompting Best Practices
-description: Prompt templates and self-check habits that measurably reduce incorrect CKB/CCC code from AI assistants.
+description: A handful of prompts that help you get accurate, working CKB/CCC code faster.
 icon: MessageSquare
 ---
-
-Even with CCC's [Agent Skills](/skill.md) loaded, *how* you ask still matters. This page collects prompt patterns that work well for CCC specifically, and the failure modes they prevent.
-
-## Match your prompt to your environment
-
-Every template on this page comes in two forms, because "reference the skill" only means something if the skill is actually sitting in the assistant's context:
-
-- **Skill-native tools** — Cursor, Claude Code, and anything else set up via [Set Up Your AI Tools](./set-up-ai-tools). The skill files are already loaded, so naming a skill (`` `ckb-ccc-fundamentals` ``) is enough — the assistant resolves it locally, no fetch needed.
-- **Web chat tools** — ChatGPT, DeepSeek, or any browser-based assistant without the `npx skills` setup. Naming a skill does nothing here; there's no file for it to resolve. Every prompt needs the actual URL, and should explicitly ask the assistant to fetch it before answering — most web chat tools can browse a URL if told to, but won't do it unprompted.
-
-If you're not sure which situation you're in: did you run the install command from [Set Up Your AI Tools](./set-up-ai-tools) in this project? If not, use the web chat version.
-
-## The core pattern: ground, then act
-
-The single most effective habit is asking the assistant to fetch specifics before generating code, instead of relying on what it already "remembers":
-
-```text
-Using CCC (@ckb-ccc/connector-react), add a button that connects a wallet and sends 100 CKB to a hardcoded address. 
-Before writing code, check https://docs.ckbccc.com/en/docs/guides/connect-wallets.md and 
-https://docs.ckbccc.com/en/docs/guides/compose-transactions.md for the current API, 
-then follow the pre-submission checklists in the ckb-ccc-fundamentals and ckb-ccc-transactions skills (https://docs.ckbccc.com/skill.md).
-```
-
-This works because it does three things a vague prompt doesn't:
-- Names the **exact package** (`@ckb-ccc/connector-react`), preventing the assistant from mixing APIs from `@ckb-ccc/core` or an unrelated package.
-- Points at **specific pages**, not "the docs" — narrower context, less noise, less chance of pulling in an unrelated example.
-- Invokes the **pre-submission checklist**, which forces a self-review pass against known gotchas (transaction ordering, `"use client"`, capacity minimums) before the code reaches you.
-
-The example above is written in the **web chat form** (full URLs) so it works everywhere. In a skill-native tool, you can shorten it: *"Using CCC (`@ckb-ccc/connector-react`), add a button that connects a wallet and sends 100 CKB to a hardcoded address. Follow the pre-submission checklists in `ckb-ccc-fundamentals` and `ckb-ccc-transactions`."* — no URLs needed, the assistant already has the skills loaded.
-
-## Before / after: what grounding actually changes
-
-Same task, two prompts, illustrating why "ground, then act" isn't just a nicety:
-
-**Vague prompt:** *"Write a function that sends 100 CKB from the connected wallet to an address using CCC."*
-
-A model relying on memorized/generic patterns typically produces something shaped like this — plausible-looking, and wrong in three CCC-specific ways:
-
+ 
+Even with [Agent Skills](https://docs.ckbccc.com/skill.md) installed, **how you ask** still decides how good the answer is. This page keeps only the patterns that actually move accuracy — copy and use directly.
+ 
+## First, know which environment you're in
+ 
+|  | Skill-native (Cursor / Claude Code, installed via the [setup guide](./set-up-ai-tools)) | Web chat (ChatGPT / DeepSeek / etc., not installed) |
+| --- | --- | --- |
+| How to use it | Just describe what you need — the tool routes itself to the right skill | Describe what you need, and also include `https://docs.ckbccc.com/skill.md`, asking it to "fetch first, then answer" — with no local files to route from, that link is what lets it find the right skill |
+ 
+Haven't run the install command from the [setup guide](./set-up-ai-tools)? Use the web chat version.
+ 
+## Core principle: verify before writing
+ 
+Without a source, the model falls back on EVM training patterns and guesses; give it a source, and it has something to check itself against. Same task, the only difference is this one sentence:
+ 
+- Vague prompt: *"Write a function using CCC that sends 100 CKB from the connected wallet."*
+- Verified prompt: *"…Before writing the code, confirm CKB-specific rules first (amount units, transaction ordering, etc.) — don't rely on training memory."* (In web chat, add `https://docs.ckbccc.com/skill.md` so it can route itself to the right rules.)
+The code each prompt produces differs in exactly these lines:
+ 
 ```ts
-// Illustrative of a common wrong answer — do not copy
-async function send(signer, toAddress) {
-  const balance = await signer.getBalance(); // ❌ treated as `number` below
-  const tx = ccc.Transaction.from({
-    outputs: [{ lock: (await ccc.Address.fromString(toAddress, signer.client)).script, capacity: 100 * 1e8 }],
-  });
-  await tx.completeFeeBy(signer);        // ❌ fee completed before inputs exist
-  await tx.completeInputsByCapacity(signer);
-  return signer.sendTransaction(tx);
-}
+// ❌ Vague prompt
+capacity: 100 * 1e8                         // number, not bigint
+await tx.completeFeeBy(signer);             // fee computed before inputs are filled
+await tx.completeInputsByCapacity(signer);
 ```
-
-**Grounded prompt:** *"Using CCC, write a function that sends 100 CKB from the connected wallet to an address. Follow the transaction pipeline order in the `ckb-ccc-transactions` skill and the Amount Conversion rules in the `ckb-ccc-fundamentals` skill (`https://docs.ckbccc.com/skill.md`) before writing code."*
-
+ 
 ```ts
-async function send(signer: ccc.Signer, toAddress: string) {
-  const { script: toLock } = await ccc.Address.fromString(toAddress, signer.client);
-  const tx = ccc.Transaction.from({
-    outputs: [{ lock: toLock, capacity: ccc.fixedPointFrom(100) }], // ✅ bigint Shannon, not a float
-  });
-  await tx.completeInputsByCapacity(signer); // ✅ inputs before fee
-  await tx.completeFeeBy(signer);
-  return signer.sendTransaction(tx);
-}
+// ✅ Verified prompt
+capacity: ccc.fixedPointFrom(100)           // bigint, in Shannon
+await tx.completeInputsByCapacity(signer);  // inputs must come before fee
+await tx.completeFeeBy(signer);
 ```
+ 
+**One rule is enough to remember: 
+- In skill-native environments, just describe the task in your own words — no need to know or type any skill name, the tool routes itself based on each skill's description. 
+- In web chat there's no local file to route from, so a `skill.md` link is the substitute for that ability.**
+ 
+## Task templates
+ 
+Web chat version = skill-native version + "fetch `https://docs.ckbccc.com/skill.md` first" — that one rule is more useful than memorizing the 7 rows below.
+ 
+| Task | What to ask (skill-native) |
+| --- | --- |
+| Not sure which package | "I'm building `<a React app / a Node.js script / a custom UI>` — which `@ckb-ccc/*` package should I use?" |
+| Implement a known guide | "Implement `<feature>` following the `<connect-wallets / compose-transactions / UDT>` guide." |
+| Debug an error | "I'm getting this error: `<error>`. Does it match a known cause in the relevant skill's common-pitfalls table?" |
+| Review AI-generated code | "Review this against the CCC pre-submit checklist and mark each item PASS/FAIL — don't just give a summary." |
+| Exact method signature | "What are the parameter types for `<method>`? Check `api.ckbccc.com`, don't guess." |
+| Find an existing example | "Is there an existing example for `<feature>` I can adapt instead of writing it from scratch?" |
+| Verify in Playground first | "Format this as a runnable script for `live.ckbccc.com` (CCC Playground) so I can test it on testnet first." |
+ 
+The rows above are single-feature prompts, narrow enough that the tool naturally matches the right skill. "Build a whole app from scratch" is too generic a phrasing, though — the AI will likely just treat it as an everyday web-dev task and never think to check the CCC rules at all. So these two examples add one generic nudge (still no specific skill name required): web chat substitutes the link, skill-native substitutes a line like "use the CCC-related skill(s)":
+ 
+**xUDT issuance/transfer app**
+- Web chat:
+  ```
+  Please visit https://docs.ckbccc.com/skill.md first, then build a React web app for me:
+  after connecting a wallet, users can issue an xUDT token and also transfer that token.
+  ```
+- Skill-native:
+  ```
+  Use the CCC-related skill(s) to build a React web app for me:
+  after connecting a wallet, users can issue an xUDT token and also transfer that token.
+  ```
+ 
+**On-chain guestbook**
+- Web chat:
+  ```
+  Please visit https://docs.ckbccc.com/skill.md first, then use the CCC SDK to build a React web app
+  on Nervos CKB: after connecting a wallet, users can post a short message, which gets written into
+  the cell data of a CKB transaction so it's permanently on-chain. The homepage lists all messages and
+  their senders' addresses, newest first.
+  ```
+- Skill-native:
+  ```
+  Use the CCC-related skill(s) to build a React web app on Nervos CKB:
+  after connecting a wallet, users can post a short message, which gets written into the cell data
+  of a CKB transaction so it's permanently on-chain. The homepage lists all messages and their
+  senders' addresses, newest first.
+  ```
 
-The fix isn't "the model got smarter" — it's that the second prompt gave it somewhere authoritative to check `completeInputsByCapacity`-before-`completeFeeBy` ordering and `bigint` Shannon amounts, instead of falling back on generic/EVM-shaped training data. This is the entire value proposition of grounding: it converts "probably right" into "checked against a source."
-
-## Prompt templates by task
-
-Each task below has a **skill-native** version (Cursor, Claude Code — skill already loaded, reference by name) and a **web chat** version (ChatGPT, DeepSeek — no skill files, always include the URL and ask it to fetch first). Swap in your own package/error/method.
-
-**New feature, unsure which package**
-- *Skill-native:* "I'm building `<React app / Node.js script / custom UI>`. Which `@ckb-ccc/*` package should I use, per the Package Selection table in `ckb-ccc-fundamentals`?"
-- *Web chat:* "I'm building `<React app / Node.js script / custom UI>` on CKB with CCC. Fetch `https://docs.ckbccc.com/skill.md`, find the `ckb-ccc-fundamentals` skill's Package Selection table, and tell me which `@ckb-ccc/*` package to use."
-
-**Implementing a known guide**
-- *Skill-native:* "Follow the `<Compose Transactions / Connect Wallets / UDT Tokens>` guide to implement `<feature>`."
-- *Web chat:* "Fetch `https://docs.ckbccc.com/en/docs/guides/<slug>.md` and follow it to implement `<feature>`. If you're not sure of the exact slug, fetch `https://docs.ckbccc.com/llms.txt` first to find the right page."
-
-**Debugging an error**
-- *Skill-native:* "I got this error: `<error>`. Check the Common Gotchas table in `ckb-ccc-fundamentals` (or the matching spoke skill) — does it match a known cause?"
-- *Web chat:* "I got this error: `<error>`. Fetch `https://docs.ckbccc.com/skill.md`, find the relevant skill (hub or spoke), and check its Common Gotchas table for a matching cause before guessing."
-
-**Reviewing AI-generated code**
-- *Skill-native:* "Review this code against the Pre-submission Checklist and Hallucination Guard in `ckb-ccc-fundamentals` and `ckb-ccc-transactions`. Go item by item and mark each PASS or FAIL — don't just summarize."
-- *Web chat:* "Fetch `https://docs.ckbccc.com/skill.md`, open the `ckb-ccc-fundamentals` and `ckb-ccc-transactions` skills, and review this code against their Pre-submission Checklists and Hallucination Guards. Go item by item and mark each PASS or FAIL — don't just summarize."
-
-**Exact method signature**
-- *Skill-native:* "What are the parameter types for `<method>` on `<class>`? Check DeepWiki/Context7 or `https://api.ckbccc.com` rather than assuming (see `ckb-ccc-fundamentals` Step 0)."
-- *Web chat:* "What are the parameter types for `<method>` on `<class>` in `@ckb-ccc/*`? Check `https://api.ckbccc.com` for the exact signature rather than assuming — don't answer from general TypeScript SDK conventions."
-
-**Looking for existing example code before writing from scratch**
-- *Skill-native:* "Is there already a working example for `<feature>` in CCC's example gallery or a demo repo, per `ckb-ccc-examples-finder`? Use that as the starting point instead of writing from scratch."
-- *Web chat:* "Fetch `https://docs.ckbccc.com/en/docs/code-examples.md` and check if there's an existing example for `<feature>`. If not, fetch `https://docs.ckbccc.com/skill.md`, open `ckb-ccc-examples-finder`, and check the external repos it lists before writing new code."
-
-**Verifying a snippet actually runs before it ships**
-- *Skill-native:* "Format this as a runnable script for the CCC Playground (per `ckb-ccc-playground`) so I can paste it into `live.ckbccc.com` and confirm it works on testnet before I put it in the real project."
-- *Web chat:* "Fetch `https://docs.ckbccc.com/skill.md`, open `ckb-ccc-playground`, and format this as a runnable script using `render()`/`signer` from `@ckb-ccc/playground` so I can paste it into `live.ckbccc.com` and confirm it works on testnet."
-
-## Habits that catch mistakes before they ship
-
-- **Ask for citations.** "Which doc page or skill section is this pattern from?" A confident answer without a citation is a signal to verify manually.
-- **Ask it to self-review with the checklist.** The pre-submission checklists in `ckb-ccc-fundamentals` and the relevant spoke skill are written to be run by an AI against its own output — explicitly ask for that pass as a separate step, not folded into the first generation.
-- **Testnet first, always.** Never accept "trust me" for anything that sends a mainnet transaction. Ask the assistant to target `ClientPublicTestnet` first and confirm behavior before switching networks — this is also called out in the relevant skill's checklist.
-- **Re-ground on version-sensitive questions.** Package versions, download counts, and newly added `KnownScript` entries change over time; re-fetch the relevant page rather than trusting a cached answer from earlier in a long conversation.
-- **Don't trust one example for protocol-level behavior.** A single file in a cookbook/demo repo can have a typo (a wrong `contentType`, a copy-pasted value) that looks internally consistent but is still wrong. For anything beyond "how do I call this method" — i.e. how a protocol like DOB/Spore is actually supposed to behave — ask it to cross-check the official protocol docs, not just the one example it found first: *"Before finalizing this, confirm the `contentType`/`decimals`/`<field>` value against the official protocol docs, not just the example you copied it from."*
-
-## The five mistakes AI makes on CKB — and how to correct them
-
-These are the CCC-specific slips even a well-configured assistant makes, because they contradict the EVM-shaped patterns in its training data. When you spot one in generated code, don't fix it by hand — hand the correction back as a prompt, so the assistant re-generates with the right rule and keeps it for the rest of the session. Each fix below is written to paste as-is.
-
-**1. Amounts come back as a `number`, or with decimals.** The model fell back on EVM-style float math. CKB amounts are always `bigint` in Shannon.
-
-> In CCC all amounts are `bigint` in Shannon, never floating point. Use `ccc.fixedPointFrom("100")` to build them and `ccc.fixedPointToString()` only at the UI boundary. Fix the code accordingly.
-
-**2. The fee is completed before the inputs.** The model didn't know CCC's pipeline is order-dependent — you can't compute a fee before inputs exist.
-
-> The transaction order is mandatory: declare outputs → `completeInputsByCapacity(signer)` → `completeFeeBy(signer)` → `sendTransaction(tx)`. Reorder the calls to match.
-
-**3. A Next.js component using `ccc.Provider` or a CCC hook throws at render.** The file is a Server Component; CCC's React pieces need the client runtime.
-
-> This file uses `ccc.Provider` / a CCC hook, so it must be a Client Component — add `"use client"` as the first line.
-
-**4. A UDT transfer silently loses token change.** The model skipped the UDT-specific input step, so surplus tokens aren't returned to the sender.
-
-> For UDT transfers, call `udt.completeBy(tx, signer)` (adds UDT inputs + change) **before** `tx.completeInputsByCapacity(signer)` (adds CKB capacity). Insert the missing step in that order.
-
-**5. A Node.js script imports `@ckb-ccc/core`.** The model reached for the low-level package unprompted; backends should use the aggregated one.
-
-> Backend/Node.js scripts should import from `@ckb-ccc/shell`, which already re-exports `@ckb-ccc/core`. Switch the import.
-
+## 5 common mistakes, one-line fixes
+ 
+If you spot any of these symptoms, just send the matching line back to the AI and have it regenerate:
+ 
+| Symptom | One-line fix |
+| --- | --- |
+| Amount is a `number` or has decimals | "CKB amounts are always a bigint in Shannon. Construct them with `ccc.fixedPointFrom()`, not a float — please fix." |
+| Fee computed before inputs are filled | "The order must be outputs → completeInputsByCapacity → completeFeeBy → sendTransaction — please reorder." |
+| Next.js component errors, missing `"use client"` | "This file uses `ccc.Provider`/a CCC hook, so it must be a client component — add `\"use client\"` as the first line." |
+| UDT transfer silently drops change | "For UDT transfers, call `completeBy(tx, signer)` first to add UDT inputs and change, then `completeInputsByCapacity` for CKB capacity — please fix the order." |
+| Node script imports from `@ckb-ccc/core` | "Backend scripts should import from `@ckb-ccc/shell` (which re-exports core) — please switch it." |
+ 
 <Callout type="info">
-  Each of these maps to an entry in the Common Gotchas and Hallucination Guard sections of `ckb-ccc-fundamentals` or the matching spoke skill — see the [skills index](/skill.md), the same one your tool loads during [setup](./set-up-ai-tools). If your assistant gets **all** of them wrong, that's not a prompting problem: the rules probably didn't load. Run the checks on [Verify & Troubleshoot](./verify-and-troubleshoot).
+  If all five come back wrong, it's probably not a prompting problem — the skill likely isn't loaded. Check [Verify & Troubleshoot](./verify-and-troubleshoot) instead of tweaking your prompt further.
 </Callout>
-
-## Closing the loop
-
-Prompting well is a habit applied per request, not a one-time step. Pair it with a correct [tool setup](./set-up-ai-tools) (so the rules are always loaded) and the [verification check](./verify-and-troubleshoot) (so you know they are), and AI-assisted CCC development gets much closer to pairing with a developer who has actually read the docs.
+## Three closing habits
+ 
+- Run mainnet-bound transactions on `ClientPublicTestnet` first — don't trust a "should work" answer.
+- For protocol-level questions (e.g. what a DOB's `contentType` should be), don't trust a single example file — have the AI cross-check the official protocol docs instead of "copying whatever example it found."
+- Don't trust what the AI said earlier in the conversation. CCC packages keep iterating and API fields change with them — the AI having "said it once" doesn't mean it's still correct. E.g. if it looked up which package to use back at message 3, and you rely on that again at message 50, don't let it just repeat its earlier answer — ask again or have it re-check.
+- Skills themselves get updated too. In skill-native environments (Cursor / Claude Code, etc.), run `npx skills update ckb-devrel/ccc` occasionally so your local copy doesn't fall behind the latest rules — but note `update` only refreshes skills you've already installed, it won't pull in newly added ones. If we add a new skill (say a future `ckb-ccc-fiber`), you'll need to re-run `npx skills add ckb-devrel/ccc --all` to get it. Web chat doesn't have this problem — it fetches `skill.md` fresh every time, so it's always current.

--- a/packages/docs/content/docs/ai-resources/prompting-best-practices.mdx
+++ b/packages/docs/content/docs/ai-resources/prompting-best-practices.mdx
@@ -36,9 +36,9 @@ await tx.completeInputsByCapacity(signer);  // inputs must come before fee
 await tx.completeFeeBy(signer);
 ```
  
-**One rule is enough to remember: 
+**One rule is enough to remember:**
 - In skill-native environments, just describe the task in your own words — no need to know or type any skill name, the tool routes itself based on each skill's description. 
-- In web chat there's no local file to route from, so a `skill.md` link is the substitute for that ability.**
+- In web chat there's no local file to route from, so a `skill.md` link is the substitute for that ability.
  
 ## Task templates
  
@@ -93,7 +93,7 @@ If you spot any of these symptoms, just send the matching line back to the AI an
 | Amount is a `number` or has decimals | "CKB amounts are always a bigint in Shannon. Construct them with `ccc.fixedPointFrom()`, not a float — please fix." |
 | Fee computed before inputs are filled | "The order must be outputs → completeInputsByCapacity → completeFeeBy → sendTransaction — please reorder." |
 | Next.js component errors, missing `"use client"` | "This file uses `ccc.Provider`/a CCC hook, so it must be a client component — add `\"use client\"` as the first line." |
-| UDT transfer silently drops change | "For UDT transfers, call `completeBy(tx, signer)` first to add UDT inputs and change, then `completeInputsByCapacity` for CKB capacity — please fix the order." |
+| UDT transfer silently drops change | "For UDT transfers, call `udt.completeBy(tx, signer)` first to add UDT inputs and change, then `completeInputsByCapacity` for CKB capacity — please fix the order." |
 | Node script imports from `@ckb-ccc/core` | "Backend scripts should import from `@ckb-ccc/shell` (which re-exports core) — please switch it." |
  
 <Callout type="info">
@@ -103,5 +103,5 @@ If you spot any of these symptoms, just send the matching line back to the AI an
  
 - Run mainnet-bound transactions on `ClientPublicTestnet` first — don't trust a "should work" answer.
 - For protocol-level questions (e.g. what a DOB's `contentType` should be), don't trust a single example file — have the AI cross-check the official protocol docs instead of "copying whatever example it found."
-- Don't trust what the AI said earlier in the conversation. CCC packages keep iterating and API fields change with them — the AI having "said it once" doesn't mean it's still correct. E.g. if it looked up which package to use back at message 3, and you rely on that again at message 50, don't let it just repeat its earlier answer — ask again or have it re-check.
+- Don't trust what the AI said earlier in the conversation. CCC packages keep iterating and API fields change with them — the AI having "said it once" doesn't mean it's still correct. E.g. if it looked up which package to use back at message 3, and you rely on that again at message 50, don't let it just repeat its earlier answer — ask it to verify the choice, not recall it.
 - Skills themselves get updated too. In skill-native environments (Cursor / Claude Code, etc.), run `npx skills update ckb-devrel/ccc` occasionally so your local copy doesn't fall behind the latest rules — but note `update` only refreshes skills you've already installed, it won't pull in newly added ones. If we add a new skill (say a future `ckb-ccc-fiber`), you'll need to re-run `npx skills add ckb-devrel/ccc --all` to get it. Web chat doesn't have this problem — it fetches `skill.md` fresh every time, so it's always current.

--- a/packages/docs/content/docs/ai-resources/prompting-best-practices.zh.mdx
+++ b/packages/docs/content/docs/ai-resources/prompting-best-practices.zh.mdx
@@ -92,7 +92,7 @@ Web 聊天版 = Skill 原生版 + "先获取 `https://docs.ckbccc.com/skill.md`"
 | 金额是 `number` 或带小数 | "CKB 数额一律是 Shannon 单位的 bigint，用 `ccc.fixedPointFrom()` 构造，别用浮点数，请修正。" |
 | 先算费用再填 input | "顺序必须是 outputs → completeInputsByCapacity → completeFeeBy → sendTransaction，请重排。" |
 | Next.js 组件报错、缺 `"use client"` | "这个文件用了 `ccc.Provider`/CCC hook，必须是客户端组件，第一行加 `\"use client\"`。" |
-| UDT 转账丢失找零 | "UDT 转账要先 `completeBy(tx, signer)` 补 UDT input 和找零，再 `completeInputsByCapacity` 补 CKB 容量，请补上顺序。" |
+| UDT 转账丢失找零 | "UDT 转账要先 `udt.completeBy(tx, signer)` 补 UDT input 和找零，再 `completeInputsByCapacity` 补 CKB 容量，请补上顺序。" |
 | Node 脚本从 `@ckb-ccc/core` 导入 | "后端脚本应从 `@ckb-ccc/shell` 导入（已重新导出 core），请切换。" |
  
 <Callout type="info">

--- a/packages/docs/content/docs/ai-resources/prompting-best-practices.zh.mdx
+++ b/packages/docs/content/docs/ai-resources/prompting-best-practices.zh.mdx
@@ -1,143 +1,107 @@
 ---
 title: 提示词最佳实践
-description: 可有效减少 AI 助手生成错误 CKB/CCC 代码的提示词模板与自查习惯。
+description: 几句好用的提示词，帮你更快写出准确、能跑的 CKB/CCC 代码。
 icon: MessageSquare
 ---
+ 
+即使装好了 [Agent Skills](https://docs.ckbccc.com/skill.md)，**怎么问**依然决定着结果的好坏。这页只留下真正影响准确率的几个模式，照抄即用。
+ 
+## 先确认你在哪种环境
+ 
+|  | Skill 原生（Cursor / Claude Code，已按[配置指南](./set-up-ai-tools)安装） | Web 聊天（ChatGPT / DeepSeek 等，未安装） |
+| --- | --- | --- |
+| 怎么用 | 把需求描述清楚就行，工具会自己路由到该用哪个 skill | 需求描述清楚之外，还要附上 `https://docs.ckbccc.com/skill.md`，并要求"先获取再回答"——它没有本地文件可路由，得靠这个链接自己去找该用哪份 skill |
 
-即使加载了 CCC 的 [Agent Skills](/skill.md)，**如何**提问仍然很重要。本页整理了特别适用于 CCC 的提示词模式，以及它们所预防的错误类型。
+若你的开发环境没有执行过[配置指南](./set-up-ai-tools)里的安装命令，就按 Web 聊天版处理。
+ 
+## 核心原则：先查证，后编写
+ 
+若不指定来源，模型可能会退回到 EVM 训练模式瞎编；给定一个来源，它就有东西可以对照检查：
+ 
+- 模糊提示词：*"用 CCC 写一个从已连接钱包转 100 CKB 的函数。"*
+- 查证提示词：*"…… 写代码前先确认 CKB 特有的规则（数额单位、交易顺序等），别凭训练记忆写。"*（Web 聊天再加一句 `https://docs.ckbccc.com/skill.md`，让它自己路由到该查哪份规则）
 
-## 根据运行环境选择提示词版本
-
-本页每个模板都有两种形式，因为"引用 skill"只有在 skill 确实存在于助手上下文中的情况下才有意义：
-
-- **Skill 原生工具** —— Cursor、Claude Code，以及通过[配置 AI 工具](./set-up-ai-tools)设置的其他工具。skill 文件已加载，因此只需提及 skill 名称（`` `ckb-ccc-fundamentals` ``）即可——助手会在本地解析，无需额外获取。
-- **Web 聊天工具** —— ChatGPT、DeepSeek，或任何未经 `npx skills` 配置的浏览器版助手。在此类环境中提及 skill 名称无效，因为无可解析的文件。每个提示词都需要提供实际 URL，并明确要求助手在回答前先获取该 URL——大多数 Web 聊天工具在被要求时可以浏览 URL，但不会主动这样做。
-
-如果不确定自己属于哪种情况：你是否在本项目中执行过[配置 AI 工具](./set-up-ai-tools)中的安装命令？如果没有，请使用 Web 聊天版本。
-
-## 核心模式：先查证，后编写
-
-最有效的一个习惯是：要求助手在生成代码前先获取具体信息，而不是依赖它已经"记住"的内容：
-
-```text
-使用 CCC（@ckb-ccc/connector-react），添加一个连接钱包并向硬编码地址发送 100 CKB 的按钮。在写代码之前，先查看
-https://docs.ckbccc.com/en/docs/guides/connect-wallets.md 和
-https://docs.ckbccc.com/en/docs/guides/compose-transactions.md 了解当前 API，
-然后遵循 ckb-ccc-fundamentals 和 ckb-ccc-transactions 技能中的提交前检查清单（https://docs.ckbccc.com/skill.md）。
-```
-
-这个写法的有效性在于它做了模糊提示词做不到的三件事：
-- 指明了**确切的包名**（`@ckb-ccc/connector-react`），防止助手混淆 `@ckb-ccc/core` 或其他无关包的 API。
-- 指向**具体页面**，而非"文档"——范围更窄，干扰更少，减少引入无关示例的可能。
-- 调用了**提交前检查清单**，强制在代码交到你手上之前，对照已知陷阱（交易排序、`"use client"`、容量最小值）进行自查。
-
-上述示例使用的是 **Web 聊天形式**（完整 URL），因此适用于所有环境。在 skill 原生工具中，可以缩短为：*"使用 CCC（`@ckb-ccc/connector-react`），添加一个连接钱包并向硬编码地址发送 100 CKB 的按钮。遵循 `ckb-ccc-fundamentals` 和 `ckb-ccc-transactions` 中的提交前检查清单。"*——无需 URL，助手已加载了 skill。
-
-## 对比：查证与否的实际差异
-
-同一任务，两种提示词，说明"先查证，后编写"并非可有可无：
-
-**模糊提示词：** *"使用 CCC 编写一个函数，从已连接钱包向一个地址发送 100 CKB。"*
-
-依赖记忆/通用模式训练的模型通常会生成类似这样的代码——看起来合理，但在 CCC 特有的三个方面是错误的：
-
+两种提示词生成的代码，差异可能就体现在这几行：
+ 
 ```ts
-// 展示常见错误答案——请勿复制
-async function send(signer, toAddress) {
-  const balance = await signer.getBalance(); // ❌ 下面将其当作 number 处理
-  const tx = ccc.Transaction.from({
-    outputs: [{ lock: (await ccc.Address.fromString(toAddress, signer.client)).script, capacity: 100 * 1e8 }],
-  });
-  await tx.completeFeeBy(signer);        // ❌ 在 inputs 填充之前完成费用计算
-  await tx.completeInputsByCapacity(signer);
-  return signer.sendTransaction(tx);
-}
+// ❌ 模糊提示词
+capacity: 100 * 1e8                         // number，不是 bigint
+await tx.completeFeeBy(signer);             // 费用算在 input 填充之前
+await tx.completeInputsByCapacity(signer);
 ```
-
-**有查证的提示词：** *"使用 CCC 编写一个函数，从已连接钱包向一个地址发送 100 CKB。在写代码之前，遵循 `ckb-ccc-transactions` 技能中的交易流水线顺序和 `ckb-ccc-fundamentals` 技能中的数额转换规则（`https://docs.ckbccc.com/skill.md`）。"*
-
+ 
 ```ts
-async function send(signer: ccc.Signer, toAddress: string) {
-  const { script: toLock } = await ccc.Address.fromString(toAddress, signer.client);
-  const tx = ccc.Transaction.from({
-    outputs: [{ lock: toLock, capacity: ccc.fixedPointFrom(100) }], // ✅ bigint Shannon，非浮点数
-  });
-  await tx.completeInputsByCapacity(signer); // ✅ inputs 在费用之前
-  await tx.completeFeeBy(signer);
-  return signer.sendTransaction(tx);
-}
+// ✅ 查证提示词
+capacity: ccc.fixedPointFrom(100)           // bigint，Shannon 单位
+await tx.completeInputsByCapacity(signer);  // input 必须先于费用
+await tx.completeFeeBy(signer);
 ```
+ 
+**记住这一条就够了：**
+- Skill 原生环境里，用你自己的话把任务说清楚就行——不用记、也不用写 skill 名字，工具会按每个 skill 的描述自己路由；
+- Web 聊天环境里没有本地文件可路由，用一句 `skill.md` 链接顶替这个能力即可。
+ 
+## 场景模板
+ 
+Web 聊天版 = Skill 原生版 + "先获取 `https://docs.ckbccc.com/skill.md`"——背这条规律，比背下面7行更有用。
+ 
+| 场景 | Skill 原生怎么问 |
+| --- | --- |
+| 不确定用哪个包 | "我要做 `<React 应用/Node脚本/…>`，该用哪个 `@ckb-ccc/*` 包？" |
+| 照指南实现功能 | "按 `<连接钱包/组装交易/UDT>` 指南实现 `<功能>`。" |
+| 调试报错 | "报错：`<错误信息>`。对照相关 skill 的常见陷阱表，是否匹配已知原因？" |
+| 审查 AI 写的代码 | "对照 CCC 相关规则的提交前检查清单，逐项打 PASS/FAIL，不要只给总结。" |
+| 查精确方法签名 | "`<方法>` 的参数类型是什么？查 `api.ckbccc.com`，不要凭猜测。" |
+| 找现成示例 | "有没有 `<功能>` 的现成示例可以参考？照着改，别从零写。" |
+| 先在 Playground 验证 | "帮我格式化成可以直接贴到 `live.ckbccc.com`（CCC Playground）跑的脚本，我先在测试网跑一遍。" |
+ 
+上面都是单功能级别的提示词，措辞本身就够窄，足以让工具自动命中对应 skill。但"从零生成一个完整应用"这种话术太宽泛，AI 很容易当成普通 web 开发直接下笔、压根不会想起来查 CCC 的规则——所以这两个例子会额外加一句通用提醒（不需要记具体 skill 名字），Web 聊天用链接顶替，Skill 原生用一句"用 CCC 相关的 skill"：
+ 
+**发行/转账 xUDT 代币的应用**
+- Web 聊天：
+  ```
+  请先访问 https://docs.ckbccc.com/skill.md，然后帮我写一个 React 网页应用：
+  连接钱包后，可以发行一个 xUDT 代币，也可以对该代币发起转账。
+  ```
+- Skill 原生：
+  ```
+  使用 CCC 相关的 skill，帮我写一个 React 网页应用：
+  连接钱包后，可以发行一个 xUDT 代币，也可以对该代币发起转账。
+  ```
+ 
+**链上留言墙**
+- Web 聊天：
+  ```
+  请先访问 https://docs.ckbccc.com/skill.md，然后用 CCC SDK 做一个 React 网页应用：
+  连接钱包后可以发一条短留言，留言内容写入一笔 CKB 交易的 cell data 里，永久上链；
+  首页按时间倒序展示所有留言和发送者地址。
+  ```
+- Skill 原生：
+  ```
+  使用 CCC 相关的 skill，做一个 React 网页应用：
+  连接钱包后可以发一条短留言，留言内容写入一笔 CKB 交易的 cell data 里，永久上链；
+  首页按时间倒序展示所有留言和发送者地址。
+  ```
 
-这里的改进并非"模型变聪明了"——而是第二个提示词给了它权威来源来核对 `completeInputsByCapacity` 必须在 `completeFeeBy` 之前调用、以及数额是 `bigint` Shannon 而非浮点数，从而避免退回到通用/EVM 训练数据的模式。这正是"查证"的全部价值所在：将"可能正确"转化为"有来源校验的正确"。
-
-## 按任务分类的提示词模板
-
-每个任务下方提供 **skill 原生**版本（Cursor、Claude Code——skill 已加载，按名称引用）和 **Web 聊天**版本（ChatGPT、DeepSeek——无 skill 文件，务必包含 URL 并要求先获取）。替换其中的包名/错误信息/方法名即可。
-
-**新功能，不确定用哪个包**
-- *Skill 原生：* "我正在构建 `<React 应用 / Node.js 脚本 / 自定义 UI>`。根据 `ckb-ccc-fundamentals` 中的包选择表格，应该用哪个 `@ckb-ccc/*` 包？"
-- *Web 聊天：* "我正在 CKB 上用 CCC 构建 `<React 应用 / Node.js 脚本 / 自定义 UI>`。获取 `https://docs.ckbccc.com/skill.md`，找到 `ckb-ccc-fundamentals` 技能的包选择表格，告诉我该用哪个 `@ckb-ccc/*` 包。"
-
-**实现一个已知指南**
-- *Skill 原生：* "按照 `<构造交易 / 连接钱包 / UDT 代币>` 指南实现 `<功能>`。"
-- *Web 聊天：* "获取 `https://docs.ckbccc.com/en/docs/guides/<slug>.md` 并按指引实现 `<功能>`。如果不确定确切的 slug，先获取 `https://docs.ckbccc.com/llms.txt` 找到正确的页面。"
-
-**调试错误**
-- *Skill 原生：* "我遇到了这个错误：`<错误信息>`。对照 `ckb-ccc-fundamentals`（或对应的 spoke skill）中的常见陷阱表格——是否匹配某个已知原因？"
-- *Web 聊天：* "我遇到了这个错误：`<错误信息>`。获取 `https://docs.ckbccc.com/skill.md`，找到相关 skill（hub 或 spoke），在生成猜测前先对照其中的常见陷阱表格。"
-
-**审查 AI 生成的代码**
-- *Skill 原生：* "对照 `ckb-ccc-fundamentals` 和 `ckb-ccc-transactions` 中的提交前检查清单和幻觉防护来审查这段代码。逐项标注 PASS 或 FAIL——不要只给总结。"
-- *Web 聊天：* "获取 `https://docs.ckbccc.com/skill.md`，打开 `ckb-ccc-fundamentals` 和 `ckb-ccc-transactions` 技能，对照其中的提交前检查清单和幻觉防护来审查这段代码。逐项标注 PASS 或 FAIL——不要只给总结。"
-
-**精确的方法签名**
-- *Skill 原生：* "`<类>` 上的 `<方法>` 的参数类型是什么？查阅 DeepWiki/Context7 或 `https://api.ckbccc.com`，不要凭猜测（参见 `ckb-ccc-fundamentals` 第 0 步）。"
-- *Web 聊天：* "`@ckb-ccc/*` 中 `<类>` 上的 `<方法>` 的参数类型是什么？查阅 `https://api.ckbccc.com` 获取精确签名，不要凭猜测——不要按通用 TypeScript SDK 惯例回答。"
-
-**寻找已有示例代码，避免从零编写**
-- *Skill 原生：* "根据 `ckb-ccc-examples-finder`，CCC 的示例库或演示仓库中是否已有 `<功能>` 的工作示例？以此为基础，不要从零编写。"
-- *Web 聊天：* "获取 `https://docs.ckbccc.com/en/docs/code-examples.md`，检查是否有 `<功能>` 的现有示例。如果没有，获取 `https://docs.ckbccc.com/skill.md`，打开 `ckb-ccc-examples-finder`，在编写新代码前检查其列出的外部仓库。"
-
-**验证代码片段在实际运行前可用**
-- *Skill 原生：* "将此格式化为 CCC Playground 的可运行脚本（按 `ckb-ccc-playground`），以便我粘贴到 `live.ckbccc.com` 上在测试网验证后再放入正式项目。"
-- *Web 聊天：* "获取 `https://docs.ckbccc.com/skill.md`，打开 `ckb-ccc-playground`，使用 `@ckb-ccc/playground` 中的 `render()`/`signer` 将其格式化为可运行脚本，以便我粘贴到 `live.ckbccc.com` 上在测试网验证后再放入正式项目。"
-
-## 在交付前发现错误的习惯
-
-- **要求引用来源。** "这个模式出自哪份文档页面或 skill 章节？" 没有引用来源的自信回答说明需要手动核实。
-- **要求用检查清单进行自查。** `ckb-ccc-fundamentals` 和相关 spoke skill 中的提交前检查清单本就是为 AI 对照自己的输出而设计的——明确要求将此自查作为独立步骤，而非合并到首次生成中。
-- **始终先在测试网运行。** 对于任何发送主网交易的内容，不要接受"相信我"。要求助手先以 `ClientPublicTestnet` 为目标，确认行为后再切换网络——相关 skill 的检查清单中也专门提到了这一点。
-- **在版本敏感问题上重新查证。** 包版本、下载量和新增加的 `KnownScript` 条目会随时间变化；重新获取相关页面，不要依赖长对话早期缓存的答案。
-- **不要仅凭一个示例来推断协议级行为。** 菜谱/演示仓库中的单个文件可能有笔误（错误的 `contentType`、复制粘贴的值），看起来内部一致但仍然是错的。对于超出"如何调用这个方法"范围的问题——即像 DOB/Spore 这样的协议实际应如何运作——要求它与官方协议文档交叉核对，而非仅凭它找到的第一个示例：*"在最终确定之前，对照官方协议文档确认 `contentType`/`decimals`/`<字段>` 的值，不要仅凭你复制的那一个示例。"*
-
-## AI 在 CKB 上常犯的五类错误及其纠正方法
-
-这些是即使配置良好的助手也容易犯的 CCC 特有错误，因为它们与其训练数据中的 EVM 模式相冲突。当在生成代码中发现这些问题时，不要手动修复——将纠正要求作为提示词回传，让助手按正确规则重新生成并在后续对话中保持。每个纠正内容可直接粘贴使用。
-
-**1. 数额返回为 `number`，或带有小数。** 模型退回到了 EVM 风格的浮点数运算。CKB 数额始终以 Shannon 为单位的 `bigint`。
-
-> 在 CCC 中所有数额均为 Shannon 单位的 `bigint`，绝非浮点数。使用 `ccc.fixedPointFrom("100")` 构造数额，仅在 UI 边界处使用 `ccc.fixedPointToString()`。请相应修正代码。
-
-**2. 费用在 inputs 之前完成计算。** 模型不知道 CCC 的流水线是有顺序依赖的——在 inputs 存在之前无法计算费用。
-
-> 交易顺序是强制的：声明 outputs → `completeInputsByCapacity(signer)` → `completeFeeBy(signer)` → `sendTransaction(tx)`。请按此顺序重排调用。
-
-**3. 使用 `ccc.Provider` 或 CCC hook 的 Next.js 组件在渲染时报错。** 该文件是服务端组件；CCC 的 React 部分需要客户端运行时环境。
-
-> 此文件使用了 `ccc.Provider` 或 CCC hook，因此必须是客户端组件——在第一行添加 `"use client"`。
-
-**4. UDT 转账静默丢失找零。** 模型跳过了 UDT 特有的 input 步骤，导致 surplus 代币未退回给发送方。
-
-> UDT 转账时，先调用 `udt.completeBy(tx, signer)`（添加 UDT inputs + 找零），**再**调用 `tx.completeInputsByCapacity(signer)`（添加 CKB 容量）。请按此顺序插入缺失的步骤。
-
-**5. Node.js 脚本从 `@ckb-ccc/core` 导入。** 模型未经提示使用了底层包；后端应使用聚合包。
-
-> 后端/Node.js 脚本应从 `@ckb-ccc/shell` 导入，该包已重新导出 `@ckb-ccc/core`。请切换导入来源。
-
+## 5类高发错误，一句话纠正
+ 
+发现下面任一症状，把对应这句话直接回传给 AI 重新生成即可：
+ 
+| 症状 | 一句纠正语 |
+| --- | --- |
+| 金额是 `number` 或带小数 | "CKB 数额一律是 Shannon 单位的 bigint，用 `ccc.fixedPointFrom()` 构造，别用浮点数，请修正。" |
+| 先算费用再填 input | "顺序必须是 outputs → completeInputsByCapacity → completeFeeBy → sendTransaction，请重排。" |
+| Next.js 组件报错、缺 `"use client"` | "这个文件用了 `ccc.Provider`/CCC hook，必须是客户端组件，第一行加 `\"use client\"`。" |
+| UDT 转账丢失找零 | "UDT 转账要先 `completeBy(tx, signer)` 补 UDT input 和找零，再 `completeInputsByCapacity` 补 CKB 容量，请补上顺序。" |
+| Node 脚本从 `@ckb-ccc/core` 导入 | "后端脚本应从 `@ckb-ccc/shell` 导入（已重新导出 core），请切换。" |
+ 
 <Callout type="info">
-  上述每一条都对应 `ckb-ccc-fundamentals` 或对应 spoke skill 中"常见陷阱"和"幻觉防护"部分的条目——参见 [skills 索引](/skill.md)，即你的工具在[配置](./set-up-ai-tools)期间加载的同一份文件。如果你的助手**全部**答错，那就不只是提示词的问题了：规则可能没有加载。请运行[验证与排查](./verify-and-troubleshoot)中的检查步骤。
+  五条全错，大概率不是提示词问题，而是 skill 没加载——去[验证与排查](./verify-and-troubleshoot)查一下，别继续在提示词上找原因。
 </Callout>
 
-## 形成闭环
-
-好的提示词习惯是每次请求时应用的习惯，而非一次性步骤。将其与正确的[工具配置](./set-up-ai-tools)（确保规则始终加载）和[验证检查](./verify-and-troubleshoot)（确保你确认它们已加载）配合使用，AI 辅助的 CCC 开发就会更接近与一位真正读过文档的开发者结对编程。
+## 三条收尾习惯
+ 
+- 主网交易前先在 `ClientPublicTestnet` 跑一遍，别信"一次过"。
+- 协议级问题（比如 DOB 的 `contentType` 该填什么）别只信一个示例文件，让 AI 去对官方协议文档，不要"抄一个凑合"。
+- 别信 AI 早些时候说过的话。CCC 的包会不断迭代，API 字段也会跟着更新，AI 在对话里"说过一次"不代表现在还对——比如第3条消息里查过一次该用哪个包，聊到第50条又用到这信息时，别让它直接照搬自己之前的答案，要重新问一遍或重新查一遍。
+- Skill 本身也会迭代更新。Skill 原生环境（Cursor / Claude Code 等）建议时不时执行一次 `npx skills update ckb-devrel/ccc`，避免本地这份 skill 落后于最新规则——但注意 `update` 只刷新已装过的 skill 内容，不会把仓库里新增的 skill 拉进来；如果我们新增了 skill（比如未来的 `ckb-ccc-fiber`），得重新跑一次 `npx skills add ckb-devrel/ccc --all` 才能装上。Web 聊天不存在这个问题——它每次都是现查 `skill.md`，天然是最新版。

--- a/packages/docs/content/docs/ai-resources/set-up-ai-tools.mdx
+++ b/packages/docs/content/docs/ai-resources/set-up-ai-tools.mdx
@@ -4,7 +4,7 @@ description: Install CCC's Agent Skills into Cursor, Claude Code, GitHub Copilot
 icon: Wrench
 ---
  
-Your AI assistant only writes correct CCC code once it's actually loading CCC's rules. CCC ships these as a set of [Agent Skills](/skill.md) — one **hub skill**, `ckb-ccc-fundamentals` (package selection, Cell model, address/amount handling, hallucination guard), plus a **spoke skill** per task area (`ckb-ccc-signer-setup`, `ckb-ccc-transactions`, `ckb-ccc-udt`, `ckb-ccc-spore`, `ckb-ccc-playground`, `ckb-ccc-examples-finder`), all committed under `skills/` in the [CCC repo](https://github.com/ckb-devrel/ccc).
+Your AI assistant only writes correct CCC code once it's actually loading CCC's rules. CCC ships these as a set of [Agent Skills](https://docs.ckbccc.com/skill.md) — one **hub skill**, `ckb-ccc-fundamentals` (package selection, Cell model, address/amount handling, hallucination guard), plus a **spoke skill** per task area (`ckb-ccc-signer-setup`, `ckb-ccc-transactions`, `ckb-ccc-udt`, `ckb-ccc-spore`, `ckb-ccc-playground`, `ckb-ccc-examples-finder`), all committed under `skills/` in the [CCC repo](https://github.com/ckb-devrel/ccc).
  
 Install them with [`skills`](https://github.com/vercel-labs/skills), the open Agent Skills CLI — it auto-discovers the `skills/` directory and writes each skill to the right path for whichever tool(s) you target:
  
@@ -63,10 +63,10 @@ The skills cover the common cases, but for anything beyond them your assistant s
  
 | Resource | URL | Use it for |
 | --- | --- | --- |
-| Skills index | [`/skill.md`](/skill.md) | The default: lists every skill (hub + spoke), what each covers, and its raw `SKILL.md` URL. Load `ckb-ccc-fundamentals` first. |
-| Docs index | [`/llms.txt`](/llms.txt) | "Which page covers topic X?" A short, linked index of every docs page — fetch first to navigate. |
+| Skills index | [`/skill.md`](https://docs.ckbccc.com/skill.md) | The default: lists every skill (hub + spoke), what each covers, and its raw `SKILL.md` URL. Load `ckb-ccc-fundamentals` first. |
+| Docs index | [`/llms.txt`](https://docs.ckbccc.com/llms.txt) | "Which page covers topic X?" A short, linked index of every docs page — fetch first to navigate. |
 | Single page as Markdown | any docs URL `+ .md` | A focused how-to on one topic, e.g. `https://docs.ckbccc.com/en/docs/guides/udt-tokens.md`. Clean Markdown, no page chrome. |
-| Full docs dump | [`/llms-full.txt`](/llms-full.txt) | A broad question spanning several topics, when you want everything in one fetch. |
+| Full docs dump | [`/llms-full.txt`](https://docs.ckbccc.com/llms-full.txt) | A broad question spanning several topics, when you want everything in one fetch. |
 | API reference | [api.ckbccc.com](https://api.ckbccc.com) | Exact method signatures, parameter types, and enum values for any `@ckb-ccc/*` export. |
  
 <Callout type="info">

--- a/packages/docs/content/docs/ai-resources/set-up-ai-tools.zh.mdx
+++ b/packages/docs/content/docs/ai-resources/set-up-ai-tools.zh.mdx
@@ -4,7 +4,7 @@ description: 通过一条命令将 CCC 的 Agent Skills 安装到 Cursor、Claud
 icon: Wrench
 ---
 
-你的 AI 助手只有在真正加载了 CCC 的规则之后，才能写出正确的 CCC 代码。CCC 将这些规则打包为一组 [Agent Skills](/skill.md)——一个 **hub skill** `ckb-ccc-fundamentals`（包含包选择、Cell 模型、地址/数额处理、幻觉防护），外加每个任务领域对应的 **spoke skill**（`ckb-ccc-signer-setup`、`ckb-ccc-transactions`、`ckb-ccc-udt`、`ckb-ccc-spore`、`ckb-ccc-playground`、`ckb-ccc-examples-finder`），全部提交在 [CCC 仓库](https://github.com/ckb-devrel/ccc) 的 `skills/` 目录下。
+你的 AI 助手只有在真正加载了 CCC 的规则之后，才能写出正确的 CCC 代码。CCC 将这些规则打包为一组 [Agent Skills](https://docs.ckbccc.com/skill.md)——一个 **hub skill** `ckb-ccc-fundamentals`（包含包选择、Cell 模型、地址/数额处理、幻觉防护），外加每个任务领域对应的 **spoke skill**（`ckb-ccc-signer-setup`、`ckb-ccc-transactions`、`ckb-ccc-udt`、`ckb-ccc-spore`、`ckb-ccc-playground`、`ckb-ccc-examples-finder`），全部提交在 [CCC 仓库](https://github.com/ckb-devrel/ccc) 的 `skills/` 目录下。
 
 使用开源 Agent Skills CLI —— [`skills`](https://github.com/vercel-labs/skills) 来安装。它会自动发现 `skills/` 目录，并将每个 skill 写入你所指定的工具的对应路径：
 
@@ -62,10 +62,10 @@ skills 覆盖了常见场景，但超出这些范围的场景，你的助手应�
 
 | 资源 | URL | 用途 |
 | --- | --- | --- |
-| Skills 索引 | [`/skill.md`](/skill.md) | 默认入口：列出所有 skill（hub + spoke）、各自覆盖范围及其原始 `SKILL.md` URL。先加载 `ckb-ccc-fundamentals`。 |
-| 文档索引 | [`/llms.txt`](/llms.txt) | "哪个页面覆盖了 X 主题？"——一份简短的、带链接的文档页面索引，先获取以导航。 |
+| Skills 索引 | [`/skill.md`](https://docs.ckbccc.com/skill.md) | 默认入口：列出所有 skill（hub + spoke）、各自覆盖范围及其原始 `SKILL.md` URL。先加载 `ckb-ccc-fundamentals`。 |
+| 文档索引 | [`/llms.txt`](https://docs.ckbccc.com/llms.txt) | "哪个页面覆盖了 X 主题？"——一份简短的、带链接的文档页面索引，先获取以导航。 |
 | 单个页面（Markdown 格式） | 任意文档 URL 后加 `.md` | 一个主题的聚焦操作指南，例如 `https://docs.ckbccc.com/en/docs/guides/udt-tokens.md`。干净的 Markdown，无页面框架。 |
-| 完整文档导出 | [`/llms-full.txt`](/llms-full.txt) | 跨越多个主题的宽泛问题，当你希望一次获取全部内容时使用。 |
+| 完整文档导出 | [`/llms-full.txt`](https://docs.ckbccc.com/llms-full.txt) | 跨越多个主题的宽泛问题，当你希望一次获取全部内容时使用。 |
 | API 参考 | [api.ckbccc.com](https://api.ckbccc.com) | 任何 `@ckb-ccc/*` 导出项的方法签名、参数类型和枚举值。 |
 
 <Callout type="info">

--- a/packages/docs/content/docs/ai-resources/verify-and-troubleshoot.mdx
+++ b/packages/docs/content/docs/ai-resources/verify-and-troubleshoot.mdx
@@ -8,15 +8,15 @@ Setting up a rule and writing a good prompt doesn't guarantee the assistant is a
 
 ## Canary questions
 
-Each of these has one objectively correct answer that a model *without* CCC's [Agent Skills](/skill.md) loaded gets wrong more often than not. Ask one after setup, or any time you suspect the assistant has stopped grounding itself. All of them are lifted directly from the Hallucination Guard / Common Gotchas tables in `ckb-ccc-fundamentals` or the matching spoke skill, so if you spot a wrong answer, that's exactly the section to point the assistant back at.
+Each of these has one objectively correct answer that a model *without* CCC's [Agent Skills](https://docs.ckbccc.com/skill.md) loaded gets wrong more often than not. Ask one after setup, or any time you suspect the assistant has stopped grounding itself. All of them are lifted directly from the Hallucination Guard / Common Gotchas tables in `ckb-ccc-fundamentals` or the matching spoke skill, so if you spot a wrong answer, that's exactly the section to point the assistant back at.
 
 | Ask | Correct answer | Wrong answer means |
 | --- | --- | --- |
 | "Does `signer.getBalance()` return a `number` or a `bigint`?" | `bigint`, in Shannon | Model is assuming EVM-style float balances |
-| "What's the correct order: build outputs, complete inputs by capacity, complete fee, then send — or complete fee before completing inputs?" | Outputs → `completeInputsByCapacity` → `completeFeeBy` → `sendTransaction` | Model doesn't know CCC's required transaction pipeline |
+| "What's the correct order for building a CKB transaction in CCC?" | Outputs → `completeInputsByCapacity` → `completeFeeBy` → `sendTransaction` | Model doesn't know CCC's required transaction pipeline |
 | "In a Next.js app using `ccc.Provider`, do I need `\"use client\"`?" | Yes | Model isn't aware of the Next.js App Router gotcha |
 | "For a UDT transfer, what has to run before `completeInputsByCapacity`?" | `udt.completeBy(tx, signer)` | Model will produce a transaction that silently drops token change |
-| "Which package should a plain Node.js script import — `@ckb-ccc/core` or `@ckb-ccc/shell`?" | `@ckb-ccc/shell` (re-exports `core`) | Model picked the low-level package unprompted, a sign it isn't consulting the Package Selection table |
+| "Which package should a plain Node.js script import?" | `@ckb-ccc/shell` (re-exports `core`) | Model picked the low-level package unprompted, a sign it isn't consulting the Package Selection table |
 
 <Callout type="info">
   A model that answers all five correctly *without* you pasting any doc content into the prompt is a model that has the relevant Agent Skills (or equivalent context) genuinely loaded. That's the bar — not "sounds confident."

--- a/packages/docs/content/docs/ai-resources/verify-and-troubleshoot.zh.mdx
+++ b/packages/docs/content/docs/ai-resources/verify-and-troubleshoot.zh.mdx
@@ -8,15 +8,15 @@ icon: ShieldCheck
 
 ## 金丝雀问题（Canary Questions）
 
-以下每个问题都有唯一正确的答案，而**未**加载 CCC 的 [Agent Skills](/skill.md) 的模型答错的概率很高。你可以在完成配置后，或在任何怀疑助手已不再基于文档回答时，选一个问题来验证。这些问题都直接取自 `ckb-ccc-fundamentals` 或对应的 spoke skill 中的"幻觉防护 / 常见陷阱"表格，因此如果你发现答案有误，可以直接将助手引导回那部分内容。
+以下每个问题都有唯一正确的答案，而**未**加载 CCC 的 [Agent Skills](https://docs.ckbccc.com/skill.md) 的模型答错的概率很高。你可以在完成配置后，或在任何怀疑助手已不再基于文档回答时，选一个问题来验证。这些问题都直接取自 `ckb-ccc-fundamentals` 或对应的 spoke skill 中的"幻觉防护 / 常见陷阱"表格，因此如果你发现答案有误，可以直接将助手引导回那部分内容。
 
 | 问题 | 正确答案 | 答错意味着 |
 | --- | --- | --- |
 | "`signer.getBalance()` 返回 `number` 还是 `bigint`？" | `bigint`，单位是 Shannon | 模型在假设 EVM 风格的浮点数余额 |
-| "正确顺序是什么：先构建输出（outputs），再按 capacity 补全输入（inputs），然后补全手续费（fee），最后发送——还是先补全手续费再补全输入？" | Outputs → `completeInputsByCapacity` → `completeFeeBy` → `sendTransaction` | 模型不了解 CCC 要求的交易构建流水线 |
+| "用 CCC 构建 CKB 交易的正确顺序是什么？" | Outputs → `completeInputsByCapacity` → `completeFeeBy` → `sendTransaction` | 模型不了解 CCC 要求的交易构建流水线 |
 | "在使用了 `ccc.Provider` 的 Next.js 应用中，是否需要 `"use client"`？" | 是 | 模型不知道 Next.js App Router 的常见陷阱 |
 | "对于 UDT 转账，在 `completeInputsByCapacity` 之前必须执行什么操作？" | `udt.completeBy(tx, signer)` | 模型生成的交易会静默丢失 UDT 找零 |
-| "普通的 Node.js 脚本应该导入哪个包——`@ckb-ccc/core` 还是 `@ckb-ccc/shell`？" | `@ckb-ccc/shell`（它重新导出了 `core`） | 模型在未被提示的情况下选了底层包，说明它没有参考"包选择"表格 |
+| "普通的 Node.js 脚本应该导入哪个包？" | `@ckb-ccc/shell`（它重新导出了 `core`） | 模型在未被提示的情况下选了底层包，说明它没有参考"包选择"表格 |
 
 <Callout type="info">
   模型能在你未向提示词中粘贴任何文档内容的情况下全部答对这五个问题，说明它确实加载了相关的 Agent Skills（或同等上下文）。这才是衡量标准——而不是"听起来很自信"。


### PR DESCRIPTION
- [x] I have read the [**Contributing Guidelines**](CONTRIBUTING.md)

## Summary

Refines the AI-resources documentation (`packages/docs/content/docs/ai-resources/`) for clarity and correctness, and surfaces this content from the README. Changes are applied to both English and Chinese versions.

## Changes

- **Absolute URLs for self-referencing links**: Converted relative documentation links to absolute URLs (e.g. `/skill.md` → `https://docs.ckbccc.com/skill.md`) in `set-up-ai-tools`. This is a pilot on a single file — the goal is to make links resolve correctly when this content is consumed outside the rendered site (e.g. fetched as raw Markdown by an AI tool, or copied into another tool's config/rules file), where relative paths have no meaningful base. A full pass across the remaining docs will follow once this is validated in practice.
- **Simplified canary questions** in `verify-and-troubleshoot` for better clarity.
- **Restructured** `prompting-best-practices` content.
- **Added an AI resources section to the README**, linking out to this doc set.
- All of the above applied consistently to both `en` and `zh` versions.

## Why

The AI-resources docs are meant to be read by AI tools and agents as much as by humans (via `/skill.md`, `.md` page exports, `llms.txt`, etc.), so link portability outside the rendered site matters more here than in typical docs pages. The canary-question and prompting-best-practices edits are clarity/readability improvements based on review of the existing content.

## Notes for reviewers

- The relative → absolute link conversion is intentionally scoped to `set-up-ai-tools` only for this PR. Other pages (e.g. the `llms.txt` reference row in this same file, and any similar self-links elsewhere) still use relative paths and are left untouched pending a broader, consistent pass in a follow-up PR.
- No changes to code, only to `packages/docs` content and the root `README.md`.

## Testing

- Verified the page renders correctly in the docs site.
- Verified the `.md` export of the updated page resolves links correctly outside the rendered site.
