### PR TITLE
fix(nip07): Persist NIP-07 public keys

### DIFF
--- a/.changeset/silver-jeans-fail.md
+++ b/.changeset/silver-jeans-fail.md
@@ -1,0 +1,7 @@
+---
+"@ckb-ccc/nip07": patch
+---
+
+fix(nip07): Persist NIP-07 public keys
+
+Now previously connected wallets can be restored without repeated authorization prompts.

--- a/packages/nip07/package.json
+++ b/packages/nip07/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "tsdown",
     "lint": "tsc --noEmit && eslint ./src",
+    "test": "vitest",
     "format": "prettier --write . && eslint --fix ./src"
   },
   "devDependencies": {
@@ -43,7 +44,8 @@
     "tsdown": "^0.22.3",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "typescript-eslint": "^8.61.1"
+    "typescript-eslint": "^8.61.1",
+    "vitest": "^4.1.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nip07/src/advanced.ts
+++ b/packages/nip07/src/advanced.ts
@@ -1,1 +1,1 @@
-export * as Nip07A from "./nip07.advanced.js";
+export * as Nip07A from "./advancedBarrel.js";

--- a/packages/nip07/src/advancedBarrel.ts
+++ b/packages/nip07/src/advancedBarrel.ts
@@ -1,0 +1,2 @@
+export * from "./connectionsStorage/index.js";
+export * from "./nip07.advanced.js";

--- a/packages/nip07/src/connectionsStorage/index.ts
+++ b/packages/nip07/src/connectionsStorage/index.ts
@@ -1,0 +1,74 @@
+import { ccc } from "@ckb-ccc/core";
+
+/**
+ * Persisted NIP-07 connection information.
+ * @public
+ */
+export interface Connection {
+  publicKey: ccc.Hex;
+}
+
+/**
+ * Repository used to restore a NIP-07 connection without contacting the wallet.
+ * @public
+ */
+export interface ConnectionsRepo {
+  get(): Promise<Connection | undefined>;
+  set(connection: Connection | undefined): Promise<void>;
+}
+
+/**
+ * Local storage based NIP-07 connection repository.
+ * @public
+ */
+export class ConnectionsRepoLocalStorage implements ConnectionsRepo {
+  constructor(private readonly storageKey = "ccc-nip07-signer") {}
+
+  async get(): Promise<Connection | undefined> {
+    let stored: string | null;
+    try {
+      stored = window.localStorage.getItem(this.storageKey);
+    } catch {
+      return;
+    }
+    if (!stored) {
+      return;
+    }
+
+    try {
+      const connection = JSON.parse(stored) as Partial<Connection>;
+      if (typeof connection.publicKey !== "string") {
+        throw new Error("Invalid persisted NIP-07 connection");
+      }
+
+      return {
+        publicKey: ccc.hexFrom(connection.publicKey),
+      };
+    } catch {
+      try {
+        window.localStorage.removeItem(this.storageKey);
+      } catch {
+        // Ignore storage cleanup failures.
+      }
+      return;
+    }
+  }
+
+  async set(connection: Connection | undefined): Promise<void> {
+    try {
+      if (!connection) {
+        window.localStorage.removeItem(this.storageKey);
+        return;
+      }
+
+      window.localStorage.setItem(
+        this.storageKey,
+        JSON.stringify({
+          publicKey: connection.publicKey,
+        }),
+      );
+    } catch {
+      // Persistence is best-effort; keep the signer's in-memory connection.
+    }
+  }
+}

--- a/packages/nip07/src/signer.test.ts
+++ b/packages/nip07/src/signer.test.ts
@@ -1,0 +1,164 @@
+import { ccc } from "@ckb-ccc/core";
+import { describe, expect, it, vi } from "vitest";
+import { Connection, ConnectionsRepo } from "./connectionsStorage/index.js";
+import { Provider } from "./nip07.advanced.js";
+import { NostrAccountChangedError, Signer } from "./signer.js";
+
+const PUBLIC_KEY_A = "11".repeat(32);
+const PUBLIC_KEY_B = "22".repeat(32);
+
+class ConnectionsRepoMemory implements ConnectionsRepo {
+  constructor(public connection?: Connection) {}
+
+  async get(): Promise<Connection | undefined> {
+    return this.connection;
+  }
+
+  async set(connection: Connection | undefined): Promise<void> {
+    this.connection = connection;
+  }
+}
+
+function createProvider(publicKey = PUBLIC_KEY_A) {
+  const getPublicKey = vi.fn(async (): Promise<string> => publicKey);
+  const signEvent = vi.fn(
+    async (event: ccc.NostrEvent): Promise<Required<ccc.NostrEvent>> => ({
+      created_at: event.created_at,
+      kind: event.kind,
+      tags: event.tags,
+      content: event.content,
+      id: "event-id",
+      pubkey: publicKey,
+      sig: "signature",
+    }),
+  );
+  const provider: Provider = {
+    getPublicKey,
+    signEvent,
+  };
+
+  return { getPublicKey, provider, signEvent };
+}
+
+function createEvent(): ccc.NostrEvent {
+  return {
+    created_at: 1,
+    kind: 1,
+    tags: [],
+    content: "test",
+  };
+}
+
+describe("NIP-07 Signer connection persistence", () => {
+  it("refreshes the persisted connection on every connect", async () => {
+    const { getPublicKey, provider } = createProvider();
+    const repo = new ConnectionsRepoMemory();
+    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    await signer.connect();
+    getPublicKey.mockResolvedValueOnce(PUBLIC_KEY_B);
+    await signer.connect();
+
+    expect(getPublicKey).toHaveBeenCalledTimes(2);
+    expect(repo.connection).toEqual({ publicKey: `0x${PUBLIC_KEY_B}` });
+  });
+
+  it("restores the persisted connection in a recreated signer", async () => {
+    const { getPublicKey, provider } = createProvider();
+    const repo = new ConnectionsRepoMemory();
+    const signerA = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    await signerA.connect();
+
+    const signerB = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    expect(await signerB.isConnected()).toBe(true);
+    expect(getPublicKey).toHaveBeenCalledTimes(1);
+    expect(await signerB.getNostrPublicKey()).toBe(`0x${PUBLIC_KEY_A}`);
+    expect(repo.connection).toEqual({ publicKey: `0x${PUBLIC_KEY_A}` });
+  });
+
+  it("restores a connection for a new provider without requesting its public key", async () => {
+    const repo = new ConnectionsRepoMemory({
+      publicKey: `0x${PUBLIC_KEY_A}`,
+    });
+    const { getPublicKey, provider } = createProvider();
+    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    expect(await signer.isConnected()).toBe(true);
+    expect(await signer.getNostrPublicKey()).toBe(`0x${PUBLIC_KEY_A}`);
+    expect(getPublicKey).not.toHaveBeenCalled();
+  });
+
+  it("removes the persisted connection on disconnect", async () => {
+    const repo = new ConnectionsRepoMemory();
+    const { provider } = createProvider();
+    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    await signer.connect();
+    await signer.disconnect();
+
+    expect(repo.connection).toBeUndefined();
+    expect(await signer.isConnected()).toBe(false);
+  });
+
+  it("does not persist a rejected connection and allows retrying", async () => {
+    const repo = new ConnectionsRepoMemory();
+    const { getPublicKey, provider } = createProvider();
+    getPublicKey
+      .mockRejectedValueOnce(new Error("Rejected"))
+      .mockResolvedValueOnce(PUBLIC_KEY_A);
+    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    await expect(signer.connect()).rejects.toThrow("Rejected");
+    expect(repo.connection).toBeUndefined();
+
+    await signer.connect();
+    expect(getPublicKey).toHaveBeenCalledTimes(2);
+    expect(repo.connection).toEqual({ publicKey: `0x${PUBLIC_KEY_A}` });
+  });
+
+  it("clears a restored connection when reconnecting is rejected", async () => {
+    const repo = new ConnectionsRepoMemory({
+      publicKey: `0x${PUBLIC_KEY_A}`,
+    });
+    const { getPublicKey, provider } = createProvider();
+    getPublicKey.mockRejectedValueOnce(new Error("Rejected"));
+    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    expect(await signer.isConnected()).toBe(true);
+    await expect(signer.connect()).rejects.toThrow("Rejected");
+
+    expect(repo.connection).toBeUndefined();
+    expect(await signer.isConnected()).toBe(false);
+  });
+
+  it("passes the restored public key to signEvent", async () => {
+    const repo = new ConnectionsRepoMemory({
+      publicKey: `0x${PUBLIC_KEY_A}`,
+    });
+    const { provider, signEvent } = createProvider();
+    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    await signer.signNostrEvent(createEvent());
+
+    expect(signEvent).toHaveBeenCalledWith({
+      ...createEvent(),
+      pubkey: PUBLIC_KEY_A,
+    });
+  });
+
+  it("clears the connection when the wallet signs with another account", async () => {
+    const repo = new ConnectionsRepoMemory({
+      publicKey: `0x${PUBLIC_KEY_A}`,
+    });
+    const { provider } = createProvider(PUBLIC_KEY_B);
+    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+
+    await expect(signer.signNostrEvent(createEvent())).rejects.toBeInstanceOf(
+      NostrAccountChangedError,
+    );
+    expect(repo.connection).toBeUndefined();
+    expect(await signer.isConnected()).toBe(false);
+  });
+});

--- a/packages/nip07/src/signer.ts
+++ b/packages/nip07/src/signer.ts
@@ -1,44 +1,105 @@
 import { ccc } from "@ckb-ccc/core";
+import {
+  Connection,
+  ConnectionsRepo,
+  ConnectionsRepoLocalStorage,
+} from "./connectionsStorage/index.js";
 import { Provider } from "./nip07.advanced.js";
+
+/**
+ * Error thrown when the wallet signs with a different account than the restored
+ * NIP-07 connection.
+ * @public
+ */
+export class NostrAccountChangedError extends Error {
+  constructor() {
+    super("The active Nostr account has changed. Please reconnect the wallet.");
+    this.name = "NostrAccountChangedError";
+  }
+}
 
 /**
  * @public
  */
 export class Signer extends ccc.SignerNostr {
-  private publicKeyCache?: Promise<string> = undefined;
+  private connection?: Connection;
 
   constructor(
     client: ccc.Client,
     public readonly provider: Provider,
+    private readonly connectionsRepo: ConnectionsRepo = new ConnectionsRepoLocalStorage(),
   ) {
     super(client);
   }
 
-  async getNostrPublicKey(): Promise<ccc.Hex> {
-    if (!this.publicKeyCache) {
-      this.publicKeyCache = this.provider.getPublicKey().catch((e) => {
-        this.publicKeyCache = undefined;
-        throw e;
-      });
+  private async assertConnection(): Promise<Connection> {
+    if (!(await this.isConnected()) || !this.connection) {
+      throw new Error("Not connected");
     }
 
-    return ccc.hexFrom(await this.publicKeyCache);
+    return this.connection;
+  }
+
+  private async saveConnection(): Promise<void> {
+    await this.connectionsRepo.set(this.connection);
+  }
+
+  private async restoreConnection(): Promise<void> {
+    this.connection = await this.connectionsRepo.get();
+  }
+
+  async getNostrPublicKey(): Promise<ccc.Hex> {
+    return (await this.assertConnection()).publicKey;
   }
 
   async signNostrEvent(
     event: ccc.NostrEvent,
   ): Promise<Required<ccc.NostrEvent>> {
-    return this.provider.signEvent({
+    const expectedPublicKey = await this.getNostrPublicKey();
+    const signedEvent = await this.provider.signEvent({
       ...event,
-      pubkey: await this.publicKeyCache,
+      pubkey: expectedPublicKey.slice(2),
     });
+
+    try {
+      if (ccc.hexFrom(signedEvent.pubkey) !== expectedPublicKey) {
+        throw new Error("Public key mismatch");
+      }
+    } catch {
+      this.connection = undefined;
+      await this.saveConnection();
+      throw new NostrAccountChangedError();
+    }
+
+    return signedEvent;
   }
 
   async connect(): Promise<void> {
-    await this.getNostrPublicKey();
+    try {
+      this.connection = {
+        publicKey: ccc.hexFrom(await this.provider.getPublicKey()),
+      };
+      await this.saveConnection();
+    } catch (error) {
+      this.connection = undefined;
+      await this.saveConnection();
+      throw error;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    await super.disconnect();
+
+    this.connection = undefined;
+    await this.saveConnection();
   }
 
   async isConnected(): Promise<boolean> {
-    return true;
+    if (this.connection) {
+      return true;
+    }
+
+    await this.restoreConnection();
+    return this.connection !== undefined;
   }
 }

--- a/packages/nip07/vitest.config.mts
+++ b/packages/nip07/vitest.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  root: import.meta.dirname,
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -859,6 +859,9 @@ importers:
       typescript-eslint:
         specifier: ^8.61.1
         version: 8.66.0(@typescript/typescript6@6.0.2)(eslint@10.8.0(jiti@2.7.0))
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.5(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.2)(tsx@4.23.5)(yaml@2.9.0))
 
   packages/okx:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,11 @@
 import { defineConfig, coverageConfigDefaults } from "vitest/config";
 
-const packages = ["packages/core", "packages/did-ckb", "packages/type-id"];
+const packages = [
+  "packages/core",
+  "packages/did-ckb",
+  "packages/nip07",
+  "packages/type-id",
+];
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Now previously connected wallets can be restored without repeated authorization prompts.

<!-- Thank you for your contribution! -->

- [x] I have read the [**Contributing Guidelines**](CONTRIBUTING.md)
