### PR TITLE
feat(connector): Add a fee rate selection scene

### DIFF
--- a/.changeset/tidy-spiders-smile.md
+++ b/.changeset/tidy-spiders-smile.md
@@ -1,0 +1,9 @@
+---
+"@ckb-ccc/connector": minor
+---
+
+feat(connector): Add a fee rate selection scene
+
+The connected-wallet view now includes a built-in fee-rate selector above the
+Manage action, with economy, automatic network recommendations, and custom
+values.

--- a/packages/connector/src/assets/fee.svg.ts
+++ b/packages/connector/src/assets/fee.svg.ts
@@ -1,0 +1,19 @@
+import { html } from "lit";
+
+export const FEE_SVG = html`
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="-3 -3 30 30"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="primary-icon"
+  >
+    <path d="M12 14l4-4" />
+    <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+  </svg>
+`;

--- a/packages/connector/src/components/button.ts
+++ b/packages/connector/src/components/button.ts
@@ -1,14 +1,24 @@
-import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.js";
+import { css, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { html, unsafeStatic } from "lit/static-html.js";
 
 @customElement("ccc-button")
 export class Button extends LitElement {
+  @property()
+  public as = "button";
+
+  @property({ type: Boolean, reflect: true })
+  public disabled = false;
+
+  @property({ type: Boolean, reflect: true })
+  public selected?: boolean;
+
   static styles = css`
     :host {
       width: 100%;
     }
 
-    button {
+    .control {
       background: none;
       color: inherit;
       border: none;
@@ -18,26 +28,30 @@ export class Button extends LitElement {
       outline: inherit;
 
       width: 100%;
+      box-sizing: border-box;
       display: flex;
       align-items: center;
       justify-content: start;
       padding: 0.75rem 1rem;
       background: var(--btn-primary);
       border-radius: 0.4rem;
+      text-align: left;
       transition: background 0.15s ease-in-out;
     }
-    button:hover {
+    .control:hover,
+    .control.selected {
       background: var(--btn-primary-hover);
     }
-    button:disabled {
+    .control:disabled {
       cursor: not-allowed;
+      opacity: 0.7;
     }
-    button:disabled:hover {
+    .control:disabled:hover {
       background: var(--btn-primary);
     }
 
-    button ::slotted(img),
-    button ::slotted(svg) {
+    .control ::slotted(img),
+    .control ::slotted(svg) {
       width: 2rem;
       height: 2rem;
       margin-right: 1rem;
@@ -50,6 +64,14 @@ export class Button extends LitElement {
   }
 
   render() {
-    return html`<button><slot></slot></button>`;
+    const tag = unsafeStatic(this.as);
+    return html`
+      <${tag}
+        class="control ${this.selected ? "selected" : ""}"
+        ?disabled=${this.disabled}
+      >
+        <slot></slot>
+      </${tag}>
+    `;
   }
 }

--- a/packages/connector/src/components/button.ts
+++ b/packages/connector/src/components/button.ts
@@ -4,6 +4,10 @@ import { html, unsafeStatic } from "lit/static-html.js";
 
 @customElement("ccc-button")
 export class Button extends LitElement {
+  /**
+   * The tag name is passed to `unsafeStatic` and must be a trusted static value,
+   * never unchecked user-controlled input.
+   */
   @property()
   public as = "button";
 

--- a/packages/connector/src/components/index.ts
+++ b/packages/connector/src/components/index.ts
@@ -2,3 +2,4 @@ import "./button-pill.js";
 import "./button.js";
 import "./copy-button.js";
 import "./dialog.js";
+import "./input.js";

--- a/packages/connector/src/components/input.ts
+++ b/packages/connector/src/components/input.ts
@@ -1,0 +1,52 @@
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+@customElement("ccc-input")
+export class Input extends LitElement {
+  @property()
+  public inputmode?: string;
+
+  @property()
+  public placeholder?: string;
+
+  @property()
+  public type = "text";
+
+  @property({ attribute: false })
+  public value = "";
+
+  render() {
+    return html`
+      <input
+        inputmode=${ifDefined(this.inputmode)}
+        placeholder=${ifDefined(this.placeholder)}
+        type=${this.type}
+        .value=${this.value}
+        @input=${(event: InputEvent) => {
+          this.value = (event.currentTarget as HTMLInputElement).value;
+        }}
+      />
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    input {
+      box-sizing: border-box;
+      width: 100%;
+      padding: 0.55rem 0.65rem;
+      border: none;
+      border-radius: 0.35rem;
+      background: var(--background);
+      color: inherit;
+      font: inherit;
+      text-align: right;
+      outline: none;
+      cursor: text;
+    }
+  `;
+}

--- a/packages/connector/src/connector/client.ts
+++ b/packages/connector/src/connector/client.ts
@@ -1,0 +1,25 @@
+import { ccc } from "@ckb-ccc/ccc";
+import { DEFAULT_MAX_FEE_RATE } from "@ckb-ccc/ccc/advancedBarrel";
+
+// @ts-expect-error TS2655: Abstract Client members are forwarded by the Proxy at runtime.
+export class ClientWithFeeRate extends ccc.Proxy.Base(ccc.Client) {
+  static readonly [ccc.Proxy.localKeys] = ["feeRate"];
+
+  public feeRate?: ccc.Num;
+
+  async getFeeRate(
+    blockRange?: ccc.NumLike,
+    options?: { maxFeeRate?: ccc.NumLike },
+  ): Promise<ccc.Num> {
+    if (this.feeRate == null) {
+      return this[ccc.Proxy.inner].getFeeRate(blockRange, options);
+    }
+
+    const maxFeeRate = ccc.numFrom(options?.maxFeeRate ?? DEFAULT_MAX_FEE_RATE);
+    if (maxFeeRate === ccc.Zero) {
+      return this.feeRate;
+    }
+
+    return ccc.numMin(this.feeRate, maxFeeRate);
+  }
+}

--- a/packages/connector/src/connector/index.ts
+++ b/packages/connector/src/connector/index.ts
@@ -5,6 +5,7 @@ import { Ref, createRef, ref } from "lit/directives/ref.js";
 import {
   CloseEvent,
   ConnectedEvent,
+  FeeRateSelectedEvent,
   SelectClientEvent,
 } from "../events/index.js";
 import { SignersController } from "../signers/index.js";
@@ -27,8 +28,14 @@ export class WebComponentConnector extends LitElement {
   @state()
   public client: ccc.Client = new ccc.ClientPublicTestnet();
   public setClient(client: ccc.Client) {
+    if (client !== this.client) {
+      this.feeRate = undefined;
+    }
     this.client = client;
   }
+
+  @state()
+  public feeRate?: ccc.Num;
 
   private signersControllerInner = new SignersController(this);
 
@@ -154,8 +161,12 @@ export class WebComponentConnector extends LitElement {
                   ?hideMark=${this.hideMark}
                   .wallet=${this.wallet}
                   .signer=${this.signer.signer}
+                  .feeRate=${this.feeRate}
                   .clientOptions=${this.clientOptions}
                   @disconnect=${() => this.disconnect()}
+                  @fee-rate-selected=${(event: FeeRateSelectedEvent) => {
+                    this.feeRate = event.feeRate;
+                  }}
                   @select-client=${(e: SelectClientEvent) =>
                     this.setClient(e.client)}
                   ${ref(this.bodyRef)}

--- a/packages/connector/src/connector/index.ts
+++ b/packages/connector/src/connector/index.ts
@@ -9,6 +9,7 @@ import {
   SelectClientEvent,
 } from "../events/index.js";
 import { SignersController } from "../signers/index.js";
+import { ClientWithFeeRate } from "./client.js";
 
 @customElement("ccc-connector")
 export class WebComponentConnector extends LitElement {
@@ -25,17 +26,25 @@ export class WebComponentConnector extends LitElement {
   @state()
   public clientOptions?: { icon?: string; client: ccc.Client; name: string }[];
 
+  private _client = new ClientWithFeeRate(new ccc.ClientPublicTestnet());
+
+  // The connector owns and may switch the active client internally, so it is
+  // state rather than an externally controlled property.
   @state()
-  public client: ccc.Client = new ccc.ClientPublicTestnet();
-  public setClient(client: ccc.Client) {
-    if (client !== this.client) {
-      this.feeRate = undefined;
+  public get client(): ccc.Client {
+    return this._client;
+  }
+  public set client(client: ccc.Client) {
+    if (client === this._client || client === this._client[ccc.Proxy.inner]) {
+      return;
     }
-    this.client = client;
+
+    this._client = new ClientWithFeeRate(client);
   }
 
-  @state()
-  public feeRate?: ccc.Num;
+  public setClient(client: ccc.Client) {
+    this.client = client;
+  }
 
   private signersControllerInner = new SignersController(this);
 
@@ -161,11 +170,12 @@ export class WebComponentConnector extends LitElement {
                   ?hideMark=${this.hideMark}
                   .wallet=${this.wallet}
                   .signer=${this.signer.signer}
-                  .feeRate=${this.feeRate}
+                  .feeRate=${this._client.feeRate}
                   .clientOptions=${this.clientOptions}
                   @disconnect=${() => this.disconnect()}
                   @fee-rate-selected=${(event: FeeRateSelectedEvent) => {
-                    this.feeRate = event.feeRate;
+                    this._client.feeRate = event.feeRate;
+                    this.requestUpdate();
                   }}
                   @select-client=${(e: SelectClientEvent) =>
                     this.setClient(e.client)}

--- a/packages/connector/src/events/index.ts
+++ b/packages/connector/src/events/index.ts
@@ -6,6 +6,12 @@ export class SelectClientEvent extends Event {
   }
 }
 
+export class FeeRateSelectedEvent extends Event {
+  constructor(public readonly feeRate?: ccc.Num) {
+    super("fee-rate-selected", { bubbles: true, composed: true });
+  }
+}
+
 export class ConnectedEvent extends Event {
   constructor(
     public readonly walletName: string,

--- a/packages/connector/src/scenes/connected.ts
+++ b/packages/connector/src/scenes/connected.ts
@@ -4,6 +4,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { CKB_SVG } from "../assets/chains/index.js";
 import { DISCONNECT_SVG } from "../assets/diconnect.svg.js";
+import { FEE_SVG } from "../assets/fee.svg.js";
 import { SWAP_SVG } from "../assets/swap.svg.js";
 import { USER_SVG } from "../assets/user.svg.js";
 import { SelectClientEvent } from "../events/index.js";
@@ -28,6 +29,8 @@ export class ConnectedScene extends LitElement {
   public wallet?: ccc.Wallet;
   @property()
   public signer?: ccc.Signer;
+  @property({ attribute: false })
+  public feeRate?: ccc.Num;
   @property()
   public clientOptions?: { icon?: string; client: ccc.Client; name: string }[];
 
@@ -39,6 +42,8 @@ export class ConnectedScene extends LitElement {
   private balance?: ccc.Num;
   @state()
   private selectingClient = false;
+  @state()
+  private selectingFeeRate = false;
 
   willUpdate(changedProperties: PropertyValues<this>): void {
     if (
@@ -66,6 +71,15 @@ export class ConnectedScene extends LitElement {
     }
 
     const body = (() => {
+      if (this.selectingFeeRate) {
+        return html`
+          <ccc-fee-rate-scene
+            .client=${signer.client}
+            .feeRate=${this.feeRate}
+          ></ccc-fee-rate-scene>
+        `;
+      }
+
       if (!this.selectingClient || !this.clientOptions) {
         return html`
           <div class="position-relative">
@@ -100,6 +114,21 @@ export class ConnectedScene extends LitElement {
 
           <ccc-button
             class="mt-2"
+            @click=${() => (this.selectingFeeRate = true)}
+          >
+            ${FEE_SVG}
+            <span>Fee Rate</span>
+            <span class="fee-rate-value">
+              ${
+                this.feeRate == null
+                  ? "Auto"
+                  : `${this.feeRate.toString()} shannons/KB`
+              }
+            </span>
+          </ccc-button>
+
+          <ccc-button
+            class="mt-1"
             @click=${() => window.open("https://mobit.app/", "_blank")}
           >
             ${USER_SVG} Manage
@@ -159,9 +188,18 @@ export class ConnectedScene extends LitElement {
 
     return html`
       <ccc-dialog
-        header=${this.selectingClient ? "Select Network" : undefined}
-        ?canBack=${this.selectingClient}
-        @back=${() => (this.selectingClient = false)}
+        header=${
+          this.selectingFeeRate
+            ? "Select Fee Rate"
+            : this.selectingClient
+              ? "Select Network"
+              : undefined
+        }
+        ?canBack=${this.selectingFeeRate || this.selectingClient}
+        @back=${() => {
+          this.selectingFeeRate = false;
+          this.selectingClient = false;
+        }}
       >
         ${body}
       </ccc-dialog>
@@ -189,6 +227,13 @@ export class ConnectedScene extends LitElement {
 
     .text-tip {
       color: var(--tip-color);
+    }
+
+    .fee-rate-value {
+      margin-left: auto;
+      color: var(--tip-color);
+      font-size: 0.85rem;
+      font-variant-numeric: tabular-nums;
     }
 
     .fs-sm {
@@ -301,5 +346,10 @@ export class ConnectedScene extends LitElement {
 
   updated() {
     this.dispatchEvent(new Event("updated", { bubbles: true, composed: true }));
+  }
+
+  public onClose() {
+    this.selectingClient = false;
+    this.selectingFeeRate = false;
   }
 }

--- a/packages/connector/src/scenes/fee-rate.ts
+++ b/packages/connector/src/scenes/fee-rate.ts
@@ -1,0 +1,238 @@
+import { ccc } from "@ckb-ccc/ccc";
+import { css, html, LitElement, PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { FeeRateSelectedEvent } from "../events/index.js";
+
+type FeeRateOption = {
+  description: string;
+  feeRate?: ccc.Num;
+  label: string;
+};
+
+const MIN_FEE_RATE = 1_000n;
+const MAX_FEE_RATE = 10_000_000n;
+
+@customElement("ccc-fee-rate-scene")
+export class FeeRateScene extends LitElement {
+  @property({ attribute: false })
+  public client!: ccc.Client;
+
+  @property({ attribute: false })
+  public feeRate?: ccc.NumLike;
+
+  @state()
+  private recommendedFeeRate?: ccc.Num;
+  @state()
+  private customFeeRate = "";
+
+  private requestId = 0;
+
+  willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("client")) {
+      void this.refreshFeeRate();
+    }
+    if (changedProperties.has("feeRate")) {
+      const feeRate =
+        this.feeRate == null ? undefined : ccc.numFrom(this.feeRate);
+      const displayedFeeRate =
+        feeRate == null && this.recommendedFeeRate != null
+          ? this.recommendedFeeRate
+          : this.isValidFeeRate(feeRate)
+            ? feeRate
+            : undefined;
+      this.customFeeRate = displayedFeeRate?.toString() ?? "";
+    }
+  }
+
+  private async refreshFeeRate() {
+    const requestId = ++this.requestId;
+
+    const feeRate = await this.client.getFeeRate();
+    if (requestId !== this.requestId) {
+      return;
+    }
+    this.recommendedFeeRate = feeRate;
+    if (
+      this.feeRate == null &&
+      !this.shadowRoot
+        ?.querySelector(".fee-rate-input")
+        ?.matches(":focus-within")
+    ) {
+      this.customFeeRate = feeRate.toString();
+    }
+  }
+
+  private get options(): FeeRateOption[] {
+    return [
+      {
+        label: "Economy",
+        description: "Lower cost, confirmation may take longer",
+        feeRate: MIN_FEE_RATE,
+      },
+      {
+        label: "Auto",
+        description:
+          this.recommendedFeeRate == null
+            ? "Loading network fee rate..."
+            : "Based on recent network activity",
+        feeRate: this.recommendedFeeRate,
+      },
+    ];
+  }
+
+  private selectCustomFeeRate(value: string) {
+    this.customFeeRate = value;
+    const feeRate = this.feeRateFromInput(value);
+    if (feeRate != null) {
+      this.dispatchEvent(new FeeRateSelectedEvent(feeRate));
+    }
+  }
+
+  private selectCustomMode() {
+    const feeRate = this.feeRateFromInput(this.customFeeRate);
+    if (feeRate != null) {
+      this.dispatchEvent(new FeeRateSelectedEvent(feeRate));
+    }
+  }
+
+  private feeRateFromInput(value: string): ccc.Num | undefined {
+    if (!/^\d+$/.test(value)) {
+      return undefined;
+    }
+    const feeRate = ccc.numFrom(value);
+    return this.isValidFeeRate(feeRate) ? feeRate : undefined;
+  }
+
+  private isValidFeeRate(feeRate: ccc.Num | undefined): feeRate is ccc.Num {
+    return (
+      feeRate != null && feeRate >= MIN_FEE_RATE && feeRate <= MAX_FEE_RATE
+    );
+  }
+
+  private get selectedOption(): "Auto" | "Economy" | undefined {
+    if (this.feeRate == null) {
+      return "Auto";
+    }
+    return ccc.numFrom(this.feeRate) === MIN_FEE_RATE ? "Economy" : undefined;
+  }
+
+  private selectOption(label: string, feeRate: ccc.Num) {
+    this.customFeeRate = feeRate.toString();
+    this.dispatchEvent(
+      new FeeRateSelectedEvent(label === "Auto" ? undefined : feeRate),
+    );
+  }
+
+  render() {
+    return html`
+      <p class="tip">Fee rate is measured in shannons per 1,000 bytes.</p>
+
+      <div class="options">
+        ${this.options.map(
+          ({ description, feeRate, label }) => html`
+            <ccc-button
+              class="fee-rate-option"
+              ?selected=${this.selectedOption === label}
+              ?disabled=${feeRate == null}
+              @click=${() => {
+                if (feeRate != null) {
+                  this.selectOption(label, feeRate);
+                }
+              }}
+            >
+              <span>
+                <strong>${label}</strong>
+                <small>${description}</small>
+              </span>
+            </ccc-button>
+          `,
+        )}
+
+        <label class="custom" @click=${() => this.selectCustomMode()}>
+          <ccc-button
+            as="div"
+            class="fee-rate-option"
+            ?selected=${this.selectedOption == null}
+          >
+            <span>
+              <strong>Custom</strong>
+              <small>
+                ${MIN_FEE_RATE.toString()}–${MAX_FEE_RATE.toString()}
+              </small>
+            </span>
+            <ccc-input
+              class="fee-rate-input"
+              inputmode="numeric"
+              type="text"
+              placeholder="shannons/KB"
+              .value=${this.customFeeRate}
+              @focus=${() => this.selectCustomMode()}
+              @input=${(event: InputEvent) =>
+                this.selectCustomFeeRate(
+                  (event.currentTarget as HTMLElement & { value: string })
+                    .value,
+                )}
+            ></ccc-input>
+          </ccc-button>
+        </label>
+      </div>
+    `;
+  }
+
+  updated() {
+    this.dispatchEvent(new Event("updated", { bubbles: true, composed: true }));
+  }
+
+  static styles = css`
+    :host {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .tip {
+      width: 100%;
+      margin: 0.5rem 0;
+      color: var(--tip-color);
+      font-size: 0.85rem;
+    }
+
+    .options {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 0.7rem;
+    }
+
+    .fee-rate-option > span:first-child {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+
+    small {
+      color: var(--tip-color);
+      font-size: 0.75rem;
+    }
+
+    .custom {
+      display: block;
+      width: 100%;
+      cursor: pointer;
+    }
+
+    .custom .fee-rate-option {
+      display: block;
+    }
+
+    .custom .fee-rate-option > span:first-child {
+      margin-right: 1rem;
+    }
+
+    .fee-rate-input {
+      width: 9rem;
+      margin-left: auto;
+    }
+  `;
+}

--- a/packages/connector/src/scenes/fee-rate.ts
+++ b/packages/connector/src/scenes/fee-rate.ts
@@ -15,7 +15,9 @@ const MAX_FEE_RATE = 10_000_000n;
 @customElement("ccc-fee-rate-scene")
 export class FeeRateScene extends LitElement {
   @property({ attribute: false })
-  public client!: ccc.Client;
+  public client!: ccc.Client & {
+    readonly [ccc.Proxy.inner]?: ccc.Client;
+  };
 
   @property({ attribute: false })
   public feeRate?: ccc.NumLike;
@@ -47,7 +49,9 @@ export class FeeRateScene extends LitElement {
   private async refreshFeeRate() {
     const requestId = ++this.requestId;
 
-    const feeRate = await this.client.getFeeRate();
+    const feeRate = await (
+      this.client[ccc.Proxy.inner] ?? this.client
+    ).getFeeRate();
     if (requestId !== this.requestId) {
       return;
     }

--- a/packages/connector/src/scenes/index.ts
+++ b/packages/connector/src/scenes/index.ts
@@ -1,2 +1,3 @@
 import "./connected.js";
+import "./fee-rate.js";
 import "./selecting/index.js";

--- a/packages/docs/content/docs/packages/core-packages/connector.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector.mdx
@@ -51,6 +51,15 @@ connector.disconnect(); // disconnect the current wallet
 connector.setClient(newClient); // switch networks
 ```
 
+## Select a transaction fee rate
+
+The connected-wallet view includes a **Fee Rate** entry above **Manage**, so
+applications do not need to provide a separate trigger. It opens the selector
+inside the same modal and offers economy, auto, and custom
+rates. Selections apply immediately; use the back button to return to the
+connected-wallet view. For now, the selection is retained by the connector UI
+only.
+
 ## Usage in plain HTML
 
 ```html

--- a/packages/docs/content/docs/packages/core-packages/connector.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector.zh.mdx
@@ -51,6 +51,13 @@ connector.disconnect(); // 断开当前钱包连接
 connector.setClient(newClient); // 切换网络
 ```
 
+## 选择交易费率
+
+连接钱包后的界面会在 **Manage** 上方显示 **Fee Rate** 入口，应用无需
+额外设计触发按钮。点击后会在同一个弹窗内进入费率选择页，并提供经济、
+自动和自定义费率。选择会立即生效，点击左上角返回连接页。目前选择
+结果只保存在 connector UI 状态中。
+
 ## 在纯 HTML 中使用
 
 ```html


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
The connected-wallet view now includes a built-in fee-rate selector above the Manage action, with economy, automatic network recommendations, and custom values.

<img width="143" height="211" alt="image" src="https://github.com/user-attachments/assets/a2072957-0681-45e4-997d-d6812e4263fc" />

<img width="140" height="140" alt="image" src="https://github.com/user-attachments/assets/38e3f7c5-6f1d-4a31-b98a-dec85c5e2854" />


- [x] I have read the [**Contributing Guidelines**](CONTRIBUTING.md)
