### PR TITLE
fix(core): close idle WebSocket transports after requests

### DIFF
--- a/.changeset/quiet-websockets-exit.md
+++ b/.changeset/quiet-websockets-exit.md
@@ -1,0 +1,5 @@
+---
+"@ckb-ccc/core": patch
+---
+
+Close idle WebSocket transports after all pending JSON-RPC requests complete.

--- a/packages/core/src/jsonRpc/transports/webSocket.test.ts
+++ b/packages/core/src/jsonRpc/transports/webSocket.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { FakeWebSocket } = vi.hoisted(() => {
+  class FakeWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    static readonly instances: FakeWebSocket[] = [];
+
+    readonly close = vi.fn(() => {
+      this.readyState = FakeWebSocket.CLOSING;
+      this.readyState = FakeWebSocket.CLOSED;
+      this.onclose?.();
+    });
+    readonly send = vi.fn();
+    readonly OPEN = FakeWebSocket.OPEN;
+    readonly CLOSING = FakeWebSocket.CLOSING;
+    readonly CLOSED = FakeWebSocket.CLOSED;
+    readyState = FakeWebSocket.CONNECTING;
+    onclose?: () => void;
+    onerror?: () => void;
+    onmessage?: (event: { data: string }) => void;
+    onopen?: () => void;
+
+    constructor(readonly url: string) {
+      FakeWebSocket.instances.push(this);
+    }
+
+    open() {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.();
+    }
+
+    message(data: string) {
+      this.onmessage?.({ data });
+    }
+  }
+
+  return { FakeWebSocket };
+});
+
+vi.mock("isomorphic-ws", () => ({ default: FakeWebSocket }));
+
+import { TransportWebSocket } from "./webSocket.js";
+
+describe("TransportWebSocket", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances.length = 0;
+  });
+
+  it("closes the socket after all pending requests complete", async () => {
+    const transport = new TransportWebSocket("ws://example.test");
+    const first = transport.request({
+      id: 0,
+      jsonrpc: "2.0",
+      method: "first",
+      params: [],
+    });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    await vi.waitFor(() => expect(socket.send).toHaveBeenCalledTimes(1));
+
+    const second = transport.request({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "second",
+      params: [],
+    });
+    await vi.waitFor(() => expect(socket.send).toHaveBeenCalledTimes(2));
+
+    socket.message(JSON.stringify({ id: 0, result: "first" }));
+    await expect(first).resolves.toEqual({ id: 0, result: "first" });
+    expect(socket.close).not.toHaveBeenCalled();
+
+    socket.message(JSON.stringify({ id: 1, result: "second" }));
+    await expect(second).resolves.toEqual({ id: 1, result: "second" });
+    expect(socket.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/jsonRpc/transports/webSocket.ts
+++ b/packages/core/src/jsonRpc/transports/webSocket.ts
@@ -51,6 +51,10 @@ export class TransportWebSocket implements Transport {
         this.ongoing.delete(id);
 
         resolve(res);
+
+        if (this.ongoing.size === 0 && socket.readyState === socket.OPEN) {
+          socket.close();
+        }
       };
       const onClose = () => {
         this.ongoing.forEach(([_, reject, timeout]) => {


### PR DESCRIPTION
Closes #444

## Summary

- Close a WebSocket transport once its last pending JSON-RPC request completes.
- Keep the connection open while concurrent requests are still pending.
- Add a regression test covering concurrent requests and idle cleanup.
- Include a patch changeset for @ckb-ccc/core.

## Testing

- `pnpm exec vitest run`
- `pnpm exec tsdown`
- targeted ESLint
- targeted Prettier check